### PR TITLE
create dashboard route with raycluster

### DIFF
--- a/src/codeflare_sdk/templates/new-template.yaml
+++ b/src/codeflare_sdk/templates/new-template.yaml
@@ -232,3 +232,19 @@ spec:
                       cpu: "2"
                       memory: "12G"
                       nvidia.com/gpu: "1"
+    - replica: 1
+      generictemplate:
+        kind: Route
+        apiVersion: route.openshift.io/v1
+        metadata:
+          name: ray-dashboard-deployment-name
+          namespace: default
+          labels:
+            # allows me to return name of service that Ray operator creates
+            odh-ray-cluster-service: deployment-name-head-svc
+        spec:
+          to:
+            kind: Service
+            name: deployment-name-head-svc
+          port:
+            targetPort: dashboard 


### PR DESCRIPTION
Updated the AppWrapper Template and the `generate_yaml.py` code to deploy a route to the ray dashboard alongside the ray cluster. 

Note: this still assumes `default` is the namespace we will be using. Can be updated in a future PR along with #23 