### PR TITLE
[WIP - Do Not Merge] Separate auth methods from cluster methods

### DIFF
--- a/demo-notebooks/batch-job/batch_mnist.ipynb
+++ b/demo-notebooks/batch-job/batch_mnist.ipynb
@@ -24,7 +24,9 @@
     "    token = \"XXXX\",\n",
     "    server = \"XXXX\",\n",
     "    skip_tls=True\n",
-    ")"
+    ")\n",
+    "\n",
+    "auth.login()"
    ]
   },
   {
@@ -43,7 +45,18 @@
    "outputs": [],
    "source": [
     "# Create our cluster and submit appwrapper\n",
-    "cluster = Cluster(ClusterConfiguration(name='mnisttest', min_worker=2, max_worker=2, min_cpus=8, max_cpus=8, min_memory=16, max_memory=16, gpu=4, instascale=True, machine_types=[\"m5.xlarge\", \"p3.8xlarge\"], auth=auth))"
+    "cluster = Cluster(ClusterConfiguration(name='mnisttest', \n",
+    "                                       min_worker=2, \n",
+    "                                       max_worker=2, \n",
+    "                                       min_cpus=8, \n",
+    "                                       max_cpus=8, \n",
+    "                                       min_memory=16, \n",
+    "                                       max_memory=16, \n",
+    "                                       gpu=4, \n",
+    "                                       instascale=True, \n",
+    "                                       machine_types=[\"m5.xlarge\", \"p3.8xlarge\"],\n",
+    "                                       )\n",
+    "                                       )"
    ]
   },
   {
@@ -1993,6 +2006,16 @@
    "outputs": [],
    "source": [
     "cluster.down()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c38ad59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth.logout()"
    ]
   }
  ],

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -82,7 +82,8 @@ class TokenAuthentication(Authentication):
         """
         This function is used to logout of an OpenShift cluster.
         """
-        response = oc.invoke("logout")
+        args = [f"--token={self.token}", f"--server={self.server}:6443"]
+        response = oc.invoke("logout", args)
         return response.out()
 
 

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -95,7 +95,6 @@ class Cluster:
         Applies the AppWrapper yaml, pushing the resource request onto
         the MCAD queue.
         """
-        self.config.auth.login()
         namespace = self.config.namespace
         with oc.project(namespace):
             oc.invoke("apply", ["-f", self.app_wrapper_yaml])
@@ -108,7 +107,6 @@ class Cluster:
         namespace = self.config.namespace
         with oc.project(namespace):
             oc.invoke("delete", ["AppWrapper", self.app_wrapper_name])
-        self.config.auth.logout()
 
     def status(self, print_to_console: bool = True):  # pragma: no cover
         """

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -47,4 +47,3 @@ class ClusterConfiguration:
     instascale: bool = False
     envs: dict = field(default_factory=dict)
     image: str = "ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103"
-    auth: Authentication = Authentication()


### PR DESCRIPTION
This PR is aimed at making working with OpenShift environments a bit more user friendly by separating the authentication process from the the cluster object. Previously we automatically logged users in and out along with the cluster.up and cluster.down commands. This introduced the problem of needing to get a new token each time they restarted their ray cluster, since it also logged them out of their OpenShift cluster. Now users can use auth.login and auth.logout to control cluster access. cluster.up and cluster.down no longer force the authentication action, and the authentication object is no longer required in the cluster config. 