### PR TITLE
Separate auth from cluster methods

### DIFF
--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -74,6 +74,8 @@ class TokenAuthentication(Authentication):
             error_msg = osp.result.err()
             if "The server uses a certificate signed by unknown authority" in error_msg:
                 return "Error: certificate auth failure, please set `skip_tls=True` in TokenAuthentication"
+            elif "invalid" in error_msg:
+                raise PermissionError(error_msg)
             else:
                 return error_msg
         return response.out()
@@ -82,7 +84,8 @@ class TokenAuthentication(Authentication):
         """
         This function is used to logout of an OpenShift cluster.
         """
-        response = oc.invoke("logout")
+        args = [f"--token={self.token}", f"--server={self.server}:6443"]
+        response = oc.invoke("logout", args)
         return response.out()
 
 

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -96,9 +96,6 @@ class Cluster:
         Applies the AppWrapper yaml, pushing the resource request onto
         the MCAD queue.
         """
-        resp = self.config.auth.login()
-        if "invalid" in resp:
-            raise PermissionError(resp)
         namespace = self.config.namespace
         try:
             with oc.project(namespace):
@@ -135,7 +132,6 @@ class Cluster:
                 print("Cluster not found, have you run cluster.up() yet?")
             else:
                 raise osp
-        self.config.auth.logout()
 
     def status(
         self, print_to_console: bool = True

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -47,4 +47,3 @@ class ClusterConfiguration:
     instascale: bool = False
     envs: dict = field(default_factory=dict)
     image: str = "ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103"
-    auth: Authentication = Authentication()

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -121,7 +121,10 @@ def test_token_auth_login_logout(mocker):
         "login",
         ["--token=testtoken", "--server=testserver:6443"],
     )
-    assert token_auth.logout() == ("logout",)
+    assert token_auth.logout() == (
+        "logout",
+        ["--token=testtoken", "--server=testserver:6443"],
+    )
 
 
 def test_token_auth_login_tls(mocker):
@@ -198,7 +201,6 @@ def test_config_creation():
         gpu=7,
         instascale=True,
         machine_types=["cpu.small", "gpu.large"],
-        auth=TokenAuthentication(token="testtoken", server="testserver"),
     )
 
     assert config.name == "unit-test-cluster" and config.namespace == "ns"
@@ -213,7 +215,6 @@ def test_config_creation():
     assert config.template == f"{parent}/src/codeflare_sdk/templates/new-template.yaml"
     assert config.instascale
     assert config.machine_types == ["cpu.small", "gpu.large"]
-    assert config.auth.__class__ == TokenAuthentication
     return config
 
 


### PR DESCRIPTION
This PR is aimed at making working with OpenShift environments a bit more user friendly by separating the authentication process from the the cluster object. Previously we automatically logged users in and out along with the cluster.up and cluster.down commands. This introduced the problem of needing to get a new token each time they restarted their ray cluster, since it also logged them out of their OpenShift cluster. Now users can use auth.login and auth.logout to control cluster access. cluster.up and cluster.down no longer force the authentication action, and the authentication object is no longer required in the cluster config.

(This is an update of #66)