### PR TITLE
Remove hard-coded port 6443 in auth

### DIFF
--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -65,7 +65,7 @@ class TokenAuthentication(Authentication):
         Depending on the cluster, a user can choose to login in with "--insecure-skip-tls-verify` by setting `skip_tls`
         to `True`.
         """
-        args = [f"--token={self.token}", f"--server={self.server}:6443"]
+        args = [f"--token={self.token}", f"--server={self.server}"]
         if self.skip_tls:
             args.append("--insecure-skip-tls-verify")
         try:
@@ -84,7 +84,7 @@ class TokenAuthentication(Authentication):
         """
         This function is used to logout of an OpenShift cluster.
         """
-        args = [f"--token={self.token}", f"--server={self.server}:6443"]
+        args = [f"--token={self.token}", f"--server={self.server}"]
         response = oc.invoke("logout", args)
         return response.out()
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -116,7 +116,7 @@ def test_token_auth_login_logout(mocker):
     mock_res = mocker.patch.object(openshift.Result, "out")
     mock_res.side_effect = lambda: att_side_effect(fake_res)
 
-    token_auth = TokenAuthentication(token="testtoken", server="testserver")
+    token_auth = TokenAuthentication(token="testtoken", server="testserver:6443")
     assert token_auth.login() == (
         "login",
         ["--token=testtoken", "--server=testserver:6443"],
@@ -137,7 +137,7 @@ def test_token_auth_login_tls(mocker):
     # assert token_auth.login() == "Error: certificate auth failure, please set `skip_tls=True` in TokenAuthentication"
 
     token_auth = TokenAuthentication(
-        token="testtoken", server="testserver", skip_tls=True
+        token="testtoken", server="testserver:6443", skip_tls=True
     )
     assert token_auth.login() == (
         "login",


### PR DESCRIPTION
Based on user feedback, we realized that hard coding the OpenShift server port was causing issues with some users preventing them from being able to log in. 

This PR simple removes the `:6443` suffix from server parameter so that the port must be explicitly included. 

We can add future PR's to include some more sophisticated server address parsing and error handling.  