### PR TITLE
Add use of priorityClasses to SDK

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -90,11 +90,15 @@ class Cluster:
         instance_types = self.config.machine_types
         env = self.config.envs
 <<<<<<< HEAD
+<<<<<<< HEAD
         local_interactive = self.config.local_interactive
         image_pull_secrets = self.config.image_pull_secrets
 =======
         priority = self.config.priority
 >>>>>>> 7e7a311 ( add priorities and schedulingSpec to SDK)
+=======
+        dispatch_priority = self.config.dispatch_priority
+>>>>>>> b1d1d16 (change 'priority' to 'dispatch priority')
         return generate_appwrapper(
             name=name,
             namespace=namespace,
@@ -110,11 +114,15 @@ class Cluster:
             instance_types=instance_types,
             env=env,
 <<<<<<< HEAD
+<<<<<<< HEAD
             local_interactive=local_interactive,
             image_pull_secrets=image_pull_secrets,
 =======
             priority=priority,
 >>>>>>> 7e7a311 ( add priorities and schedulingSpec to SDK)
+=======
+            dispatch_priority=dispatch_priority,
+>>>>>>> b1d1d16 (change 'priority' to 'dispatch priority')
         )
 
     # creates a new cluster with the provided or default spec

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -89,8 +89,12 @@ class Cluster:
         instascale = self.config.instascale
         instance_types = self.config.machine_types
         env = self.config.envs
+<<<<<<< HEAD
         local_interactive = self.config.local_interactive
         image_pull_secrets = self.config.image_pull_secrets
+=======
+        priority = self.config.priority
+>>>>>>> 7e7a311 ( add priorities and schedulingSpec to SDK)
         return generate_appwrapper(
             name=name,
             namespace=namespace,
@@ -105,8 +109,12 @@ class Cluster:
             instascale=instascale,
             instance_types=instance_types,
             env=env,
+<<<<<<< HEAD
             local_interactive=local_interactive,
             image_pull_secrets=image_pull_secrets,
+=======
+            priority=priority,
+>>>>>>> 7e7a311 ( add priorities and schedulingSpec to SDK)
         )
 
     # creates a new cluster with the provided or default spec

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -89,16 +89,9 @@ class Cluster:
         instascale = self.config.instascale
         instance_types = self.config.machine_types
         env = self.config.envs
-<<<<<<< HEAD
-<<<<<<< HEAD
         local_interactive = self.config.local_interactive
         image_pull_secrets = self.config.image_pull_secrets
-=======
-        priority = self.config.priority
->>>>>>> 7e7a311 ( add priorities and schedulingSpec to SDK)
-=======
         dispatch_priority = self.config.dispatch_priority
->>>>>>> b1d1d16 (change 'priority' to 'dispatch priority')
         return generate_appwrapper(
             name=name,
             namespace=namespace,
@@ -113,16 +106,9 @@ class Cluster:
             instascale=instascale,
             instance_types=instance_types,
             env=env,
-<<<<<<< HEAD
-<<<<<<< HEAD
             local_interactive=local_interactive,
             image_pull_secrets=image_pull_secrets,
-=======
-            priority=priority,
->>>>>>> 7e7a311 ( add priorities and schedulingSpec to SDK)
-=======
             dispatch_priority=dispatch_priority,
->>>>>>> b1d1d16 (change 'priority' to 'dispatch priority')
         )
 
     # creates a new cluster with the provided or default spec

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -47,4 +47,4 @@ class ClusterConfiguration:
     image: str = "quay.io/project-codeflare/ray:2.5.0-py38-cu116"
     local_interactive: bool = False
     image_pull_secrets: list = field(default_factory=list)
-
+    dispatch_priority: str = "default"

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -47,3 +47,4 @@ class ClusterConfiguration:
     image: str = "quay.io/project-codeflare/ray:2.5.0-py38-cu116"
     local_interactive: bool = False
     image_pull_secrets: list = field(default_factory=list)
+

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -47,4 +47,4 @@ class ClusterConfiguration:
     image: str = "quay.io/project-codeflare/ray:2.5.0-py38-cu116"
     local_interactive: bool = False
     image_pull_secrets: list = field(default_factory=list)
-    dispatch_priority: str = "default"
+    dispatch_priority: str = None

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -114,7 +114,6 @@ spec:
                           operator: In
                           values:
                           - "aw-kuberay"
-                priorityClassName: "default-priority"
                 containers:
                 # The Ray head pod
                 - env:
@@ -224,7 +223,6 @@ spec:
                           operator: In
                           values:
                           - "aw-kuberay"
-                priorityClassName: "default-priority"
                 initContainers:
                 # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
                 - name: init-myservice

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -8,6 +8,8 @@ metadata:
     orderedinstance: "m4.xlarge_g4dn.xlarge"
 spec:
   priority: 9
+  schedulingSpec:
+    minAvailable: 3
   resources:
     Items: []
     GenericItems:
@@ -112,6 +114,7 @@ spec:
                           operator: In
                           values:
                           - "aw-kuberay"
+                priorityClassName: "default-priority"
                 containers:
                 # The Ray head pod
                 - env:
@@ -221,6 +224,7 @@ spec:
                           operator: In
                           values:
                           - "aw-kuberay"
+                priorityClassName: "default-priority"
                 initContainers:
                 # the env var $RAY_IP is set by the operator if missing, with the value of the head service name
                 - name: init-myservice

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -372,7 +372,7 @@ def generate_appwrapper(
     env,
     local_interactive: bool,
     image_pull_secrets: list,
-    priority: str,
+    dispatch_priority: str,
 ):
     user_yaml = read_template(template)
     appwrapper_name, cluster_name = gen_names(name)
@@ -381,7 +381,7 @@ def generate_appwrapper(
     route_item = resources["resources"].get("GenericItems")[1]
     update_names(user_yaml, item, appwrapper_name, cluster_name, namespace)
     update_labels(user_yaml, instascale, instance_types)
-    update_priority(user_yaml, item, priority)
+    update_priority(user_yaml, item, dispatch_priority)
     update_scheduling_spec(user_yaml, workers)
     update_custompodresources(
         item, min_cpu, max_cpu, min_memory, max_memory, gpu, workers

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -89,26 +89,12 @@ def update_labels(yaml, instascale, instance_types):
         metadata.pop("labels")
 
 
-PRIORITY_LEVELS = {
-    "low": (1, "low-priority"),
-    "default": (5, "default-priority"),
-    "high": (10, "high-priority"),
-}
-
-
-def update_priority(yaml, item, priority):
-    if priority not in PRIORITY_LEVELS:
-        sys.exit("Priority must be 'low', 'default', or 'high'")
-
-    priority_level = PRIORITY_LEVELS[priority]
-    spec = yaml.get("spec")
-    spec["priority"] = priority_level[0]
-    # spec["SchedulingSpec"]["priorityClassName"] = priority_level
-    if "generictemplate" in item.keys():
+def update_priority(item, dispatch_priority):
+    if dispatch_priority is not None:
         head = item.get("generictemplate").get("spec").get("headGroupSpec")
         worker = item.get("generictemplate").get("spec").get("workerGroupSpecs")[0]
-        head["template"]["spec"]["priorityClassName"] = priority_level[1]
-        worker["template"]["spec"]["priorityClassName"] = priority_level[1]
+        head["template"]["spec"]["priorityClassName"] = dispatch_priority
+        worker["template"]["spec"]["priorityClassName"] = dispatch_priority
 
 
 def update_custompodresources(
@@ -382,7 +368,7 @@ def generate_appwrapper(
     route_item = resources["resources"].get("GenericItems")[1]
     update_names(user_yaml, item, appwrapper_name, cluster_name, namespace)
     update_labels(user_yaml, instascale, instance_types)
-    update_priority(user_yaml, item, dispatch_priority)
+    update_priority(item, dispatch_priority)
     update_scheduling_spec(user_yaml, workers)
     update_custompodresources(
         item, min_cpu, max_cpu, min_memory, max_memory, gpu, workers

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -89,17 +89,18 @@ def update_labels(yaml, instascale, instance_types):
         metadata.pop("labels")
 
 
+PRIORITY_LEVELS = {
+    "low": (1, "low-priority"),
+    "default": (5, "default-priority"),
+    "high": (10, "high-priority"),
+}
+
+
 def update_priority(yaml, item, priority):
-    if priority not in ["low", "default", "high"]:
+    if priority not in PRIORITY_LEVELS:
         sys.exit("Priority must be 'low', 'default', or 'high'")
 
-    priority_levels = {
-        "low": (1, "low-priority"),
-        "default": (5, "default-priority"),
-        "high": (10, "high-priority"),
-    }
-
-    priority_level = priority_levels[priority]
+    priority_level = PRIORITY_LEVELS[priority]
     spec = yaml.get("spec")
     spec["priority"] = priority_level[0]
     # spec["SchedulingSpec"]["priorityClassName"] = priority_level

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -6,7 +6,7 @@ metadata:
   name: unit-test-cluster
   namespace: ns
 spec:
-  priority: 9
+  priority: 1
   resources:
     GenericItems:
     - custompodresources:
@@ -176,6 +176,7 @@ spec:
                     do echo waiting for myservice; sleep 2; done
                   image: busybox:1.28
                   name: init-myservice
+                priorityClassName: low-priority
       replicas: 1
     - generictemplate:
         apiVersion: route.openshift.io/v1
@@ -193,3 +194,5 @@ spec:
             name: unit-test-cluster-head-svc
       replicas: 1
     Items: []
+  schedulingSpec:
+    minAvailable: 3

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -6,7 +6,7 @@ metadata:
   name: unit-test-cluster
   namespace: ns
 spec:
-  priority: 5
+  priority: 9
   resources:
     GenericItems:
     - custompodresources:
@@ -109,6 +109,7 @@ spec:
                       nvidia.com/gpu: 0
                 imagePullSecrets:
                 - name: unit-test-pull-secret
+                priorityClassName: default
           rayVersion: 2.5.0
           workerGroupSpecs:
           - groupName: small-group-unit-test-cluster
@@ -176,7 +177,7 @@ spec:
                     do echo waiting for myservice; sleep 2; done
                   image: busybox:1.28
                   name: init-myservice
-                priorityClassName: default-priority
+                priorityClassName: default
       replicas: 1
     - generictemplate:
         apiVersion: route.openshift.io/v1
@@ -192,7 +193,7 @@ spec:
           to:
             kind: Service
             name: unit-test-cluster-head-svc
-      replica: 1
+      replicas: 1
     Items: []
   schedulingSpec:
     minAvailable: 3

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -192,7 +192,7 @@ spec:
           to:
             kind: Service
             name: unit-test-cluster-head-svc
-      replicas: 1
+      replica: 1
     Items: []
   schedulingSpec:
     minAvailable: 3

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -6,7 +6,7 @@ metadata:
   name: unit-test-cluster
   namespace: ns
 spec:
-  priority: 1
+  priority: 5
   resources:
     GenericItems:
     - custompodresources:
@@ -176,7 +176,7 @@ spec:
                     do echo waiting for myservice; sleep 2; done
                   image: busybox:1.28
                   name: init-myservice
-                priorityClassName: low-priority
+                priorityClassName: default-priority
       replicas: 1
     - generictemplate:
         apiVersion: route.openshift.io/v1

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -247,7 +247,6 @@ def test_config_creation():
 
 def test_cluster_creation():
     cluster = Cluster(test_config_creation())
-    print(cluster.app_wrapper_yaml)
     assert cluster.app_wrapper_yaml == "unit-test-cluster.yaml"
     assert cluster.app_wrapper_name == "unit-test-cluster"
     assert filecmp.cmp(

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -302,6 +302,10 @@ def test_cluster_up_down(mocker):
         "kubernetes.client.CustomObjectsApi.delete_namespaced_custom_object",
         side_effect=arg_check_del_effect,
     )
+    mocker.patch(
+        "kubernetes.client.CustomObjectsApi.list_cluster_custom_object",
+        return_value={"items": []},
+    )
     cluster = test_cluster_creation()
     cluster.up()
     cluster.down()

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -228,6 +228,7 @@ def test_config_creation():
         instascale=True,
         machine_types=["cpu.small", "gpu.large"],
         image_pull_secrets=["unit-test-pull-secret"],
+        priority="low",
     )
 
     assert config.name == "unit-test-cluster" and config.namespace == "ns"
@@ -240,11 +241,13 @@ def test_config_creation():
     assert config.instascale
     assert config.machine_types == ["cpu.small", "gpu.large"]
     assert config.image_pull_secrets == ["unit-test-pull-secret"]
+    assert config.priority == "low"
     return config
 
 
 def test_cluster_creation():
     cluster = Cluster(test_config_creation())
+    print(cluster.app_wrapper_yaml)
     assert cluster.app_wrapper_yaml == "unit-test-cluster.yaml"
     assert cluster.app_wrapper_name == "unit-test-cluster"
     assert filecmp.cmp(

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -228,7 +228,7 @@ def test_config_creation():
         instascale=True,
         machine_types=["cpu.small", "gpu.large"],
         image_pull_secrets=["unit-test-pull-secret"],
-        priority="low",
+        dispatch_priority="default",
     )
 
     assert config.name == "unit-test-cluster" and config.namespace == "ns"
@@ -241,7 +241,7 @@ def test_config_creation():
     assert config.instascale
     assert config.machine_types == ["cpu.small", "gpu.large"]
     assert config.image_pull_secrets == ["unit-test-pull-secret"]
-    assert config.priority == "low"
+    assert config.dispatch_priority == "default"
     return config
 
 


### PR DESCRIPTION
This PR enables the use of `PriorityClasses` for our RayClusters. 

closes #182 

* Adds a new parameter `dispatch_priority` to `ClusterConfig`
* If `dispatch_priority` is left empty, appwrapper is not affected. 
* If `dispatch_priority` is used, then appwrapper adds the field `priorityClassName` to the head and worker group specs. 
* Also adds functionality to check the validity of the appwrapper during `cluster.up()`. This addition is required as not all values for `dispatch_priority` are valid and the cluster needs to be checked for valid values before applying the appwrapper. 