### PR TITLE
fix error preventing NB users from installing from pip

### DIFF
--- a/custom-nb-image/Dockerfile
+++ b/custom-nb-image/Dockerfile
@@ -27,3 +27,6 @@ RUN pip install codeflare-sdk==0.4.3 \
 				datasets==2.6.1 \
 				transformers==4.23.1 \
 				evaluate==0.3.0
+
+RUN chmod -R g+w /opt/app-root/lib/python3.8/site-packages && \
+	fix-permissions /opt/app-root -P


### PR DESCRIPTION
Resolves #126

In this PR we update the permissions during the image build so that users no longer get an error when trying to install some packages via pip. 
