### PR TITLE
Add support for image pull secrets for Ray Cluster images

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -85,6 +85,7 @@ class Cluster:
         instance_types = self.config.machine_types
         env = self.config.envs
         local_interactive = self.config.local_interactive
+        image_pull_secrets = self.config.image_pull_secrets
         return generate_appwrapper(
             name=name,
             namespace=namespace,
@@ -100,6 +101,7 @@ class Cluster:
             instance_types=instance_types,
             env=env,
             local_interactive=local_interactive,
+            image_pull_secrets=image_pull_secrets,
         )
 
     # creates a new cluster with the provided or default spec

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -49,3 +49,4 @@ class ClusterConfiguration:
     envs: dict = field(default_factory=dict)
     image: str = "ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103"
     local_interactive: bool = False
+    image_pull_secrets: list = field(default_factory=list)

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -142,11 +142,10 @@ def update_image(spec, image):
 
 
 def update_image_pull_secrets(spec, image_pull_secrets):
-    if image_pull_secrets:
-        if "imagePullSecrets" not in spec:
-            spec["imagePullSecrets"] = []
-        for image_pull_secret in image_pull_secrets:
-            spec["imagePullSecrets"].append({"name": image_pull_secret})
+    template_secrets = spec.get("imagePullSecrets", [])
+    spec["imagePullSecrets"] = template_secrets + [
+        {"name": x} for x in image_pull_secrets
+    ]
 
 
 def update_env(spec, env):

--- a/tests/test-case-cmd.yaml
+++ b/tests/test-case-cmd.yaml
@@ -96,6 +96,7 @@ spec:
                       cpu: 2
                       memory: 8G
                       nvidia.com/gpu: 0
+                imagePullSecrets: []
           rayVersion: 2.1.0
           workerGroupSpecs:
           - groupName: small-group-unit-cmd-cluster
@@ -144,6 +145,7 @@ spec:
                       cpu: 1
                       memory: 2G
                       nvidia.com/gpu: 1
+                imagePullSecrets: []
                 initContainers:
                 - command:
                   - sh

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -107,6 +107,8 @@ spec:
                       cpu: 2
                       memory: 8G
                       nvidia.com/gpu: 0
+                imagePullSecrets:
+                - name: unit-test-pull-secret
           rayVersion: 2.1.0
           workerGroupSpecs:
           - groupName: small-group-unit-test-cluster
@@ -164,6 +166,8 @@ spec:
                       cpu: 3
                       memory: 5G
                       nvidia.com/gpu: 7
+                imagePullSecrets:
+                - name: unit-test-pull-secret
                 initContainers:
                 - command:
                   - sh

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -220,6 +220,7 @@ def test_config_creation():
         gpu=7,
         instascale=True,
         machine_types=["cpu.small", "gpu.large"],
+        image_pull_secrets=["unit-test-pull-secret"],
     )
 
     assert config.name == "unit-test-cluster" and config.namespace == "ns"
@@ -234,6 +235,7 @@ def test_config_creation():
     assert config.template == f"{parent}/src/codeflare_sdk/templates/base-template.yaml"
     assert config.instascale
     assert config.machine_types == ["cpu.small", "gpu.large"]
+    assert config.image_pull_secrets == ["unit-test-pull-secret"]
     return config
 
 


### PR DESCRIPTION
Fixes #147

This pr adds the configuration to supply zero or more image pull secrets within the pod specification. Enabling access to private image registries.

```
imagePullSecrets:
 -name: <image-pull-secret>
```