### PR TITLE
add .venv and build directory to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 Pipfile
 Pipfile.lock
 poetry.lock
+.venv*
+build/


### PR DESCRIPTION
Added poetry build directory to gitignore as well as any python venv directory starting with `.venv`