### PR TITLE
GitHub Release Action Fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,9 @@ on:
             release-version:
               type: string
               required: true
-              description: 'Version number (for example: 0.1.0)'
-            is-latest:
-              description: 'Select if the built image should be tagged as latest'
+              description: 'Version number (This should not include `v`, for example: 0.1.0)'
+            is-stable:
+              description: 'Select if the built image should be tagged as stable'
               required: true
               type: boolean
             quay-organization:
@@ -57,25 +57,27 @@ jobs:
               uses: stefanzweifel/git-auto-commit-action@v4
               with:
                 file_pattern: 'docs'
-                commit_message: "Changes in docs for release: v${{ github.event.inputs.release-version }}"
-            - name: Create Github release
-              uses: ncipollo/release-action@v1
-              with:
-                  tag: "v${{ github.event.inputs.release-version }}"
+                commit_message: "Changes in docs for release: ${{ github.event.inputs.release-version }}"
 
             - name: Image Build
               run: |
                 cd custom-nb-image
-                docker build --build-arg SDK_VERSION="${{ github.event.inputs.release-version }}" -t quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }} .
-                docker tag quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }} quay.io/${{ github.event.inputs.quay-organization }}/notebook:latest
+                podman build --build-arg SDK_VERSION="${{ github.event.inputs.release-version }}" -t quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }} .
+
             - name: Login to Quay.io
               uses: docker/login-action@v2
               with:
                 registry: quay.io
                 username: ${{ secrets.QUAY_ID }}
                 password: ${{ secrets.QUAY_TOKEN }}
+
             - name: Image Push
-              run: docker push quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }}
-            - name: Image Push Latest
-              if: ${{ inputs.is-latest }}
-              run: docker push quay.io/${{ github.event.inputs.quay-organization }}/notebook:latest
+              run: |
+                podman push quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }}
+                podman push quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }} quay.io/${{ github.event.inputs.quay-organization }}/notebook:stable
+
+            - name: Create Github release
+              uses: ncipollo/release-action@v1
+              with:
+                  tag: "${{ github.event.inputs.release-version }}"
+                  generateReleaseNotes: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,6 +74,10 @@ jobs:
             - name: Image Push
               run: |
                 podman push quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }}
+
+            - name: Image Push Stable
+              if: ${{github.event.inputs.is-stable}}
+              run: |
                 podman push quay.io/${{ github.event.inputs.quay-organization }}/notebook:v${{ github.event.inputs.release-version }} quay.io/${{ github.event.inputs.quay-organization }}/notebook:stable
 
             - name: Create Github release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,5 +83,5 @@ jobs:
             - name: Create Github release
               uses: ncipollo/release-action@v1
               with:
-                  tag: "${{ github.event.inputs.release-version }}"
+                  tag: "v${{ github.event.inputs.release-version }}"
                   generateReleaseNotes: true


### PR DESCRIPTION
This fixes a few issues that were discovered in the CodeFlare 0.0.5 release

1. Change version tag input to require `v` as part of the tag for consistency
2. Tag image as stable, not latest. We have switched over to using podman as well
3. Update github release step to include release notes
4. Move github tag + release step to end