### PR TITLE
Downgrade pydantic to prevent breaking introduced by pydantic 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ rich==12.5.1
 ray[default]==2.5.0
 kubernetes>=25.3.0,<27
 codeflare-torchx==0.6.0.dev0
+pydantic<2 # 2.0+ broke ray[default] see detail: https://github.com/ray-project/ray/pull/37000


### PR DESCRIPTION
Downgrad pydantic package to prevent breaking from doing `pip install -r requirements.txt`
Fixes #214
How to test:
```sh
# clone the branch
git clone --single-branch --branch limit-pydantic-version  https://github.com/tedhtchang/codeflare-sdk.git
cd codeflare-sdk/

# create new python virtual env with [pyenv](https://github.com/pyenv/pyenv#automatic-installer)
pyenv install 3.8.13
pyenv virtualenv 3.8.13 limit-pydantic-version
pyenv local limit-pydantic-version
pip install -r requirements.txt
```
verify pydantic < 2.0.*
<img width="651" alt="image" src="https://github.com/project-codeflare/codeflare-sdk/assets/7155778/782f5886-3032-4614-bdf4-e1c8fe98b5a4">
