### PR TITLE
CLI Authentication

### DIFF
--- a/src/codeflare_sdk/cli/cli_utils.py
+++ b/src/codeflare_sdk/cli/cli_utils.py
@@ -50,7 +50,8 @@ def load_auth():
             auth = pickle.load(file)
             sdk_auth.api_client = auth.create_client()
             sdk_auth.config_path = auth.k8_config_path
+            return auth
     except IOError:
-        raise "Not logged into Kubernetes cluster"
+        return None
     except EOFError:
-        raise "Not logged into Kubernetes cluster"
+        return None

--- a/src/codeflare_sdk/cli/cli_utils.py
+++ b/src/codeflare_sdk/cli/cli_utils.py
@@ -1,5 +1,10 @@
 import ast
 import click
+from kubernetes import client
+import pickle
+
+from codeflare_sdk.cluster.auth import _create_api_client_config
+import codeflare_sdk.cluster.auth as sdk_auth
 
 
 class PythonLiteralOption(click.Option):
@@ -10,3 +15,42 @@ class PythonLiteralOption(click.Option):
             return ast.literal_eval(value)
         except:
             raise click.BadParameter(value)
+
+
+class AuthenticationConfig:
+    """
+    Authentication configuration that will be stored in a file once
+    the user logs in using `codeflare login`
+    """
+
+    def __init__(
+        self,
+        token: str,
+        server: str,
+        skip_tls: bool,
+        ca_cert_path: str,
+        k8_config_path: str,
+    ):
+        self.api_client_config = _create_api_client_config(
+            token, server, skip_tls, ca_cert_path
+        )
+        self.k8_config_path = k8_config_path
+
+    def create_client(self):
+        return client.ApiClient(self.api_client_config)
+
+
+def load_auth():
+    """
+    Loads AuthenticationConfiguration and stores it in global variables
+    which can be used by the SDK for authentication
+    """
+    try:
+        with open("auth", "rb") as file:
+            auth = pickle.load(file)
+            sdk_auth.api_client = auth.create_client()
+            sdk_auth.config_path = auth.k8_config_path
+    except IOError:
+        raise "Not logged into Kubernetes cluster"
+    except EOFError:
+        raise "Not logged into Kubernetes cluster"

--- a/src/codeflare_sdk/cli/cli_utils.py
+++ b/src/codeflare_sdk/cli/cli_utils.py
@@ -2,6 +2,7 @@ import ast
 import click
 from kubernetes import client, config
 import pickle
+import os
 
 from codeflare_sdk.cluster.auth import _create_api_client_config
 from codeflare_sdk.utils.kube_api_helpers import _kube_api_error_handling
@@ -47,7 +48,8 @@ def load_auth():
     which can be used by the SDK for authentication
     """
     try:
-        with open("auth", "rb") as file:
+        auth_file_path = os.path.expanduser("~/.codeflare/auth")
+        with open(auth_file_path, "rb") as file:
             auth = pickle.load(file)
             sdk_auth.api_client = auth.create_client()
             return auth

--- a/src/codeflare_sdk/cli/cli_utils.py
+++ b/src/codeflare_sdk/cli/cli_utils.py
@@ -35,6 +35,8 @@ class AuthenticationConfig:
             token, server, skip_tls, ca_cert_path
         )
         self.k8_config_path = k8_config_path
+        self.server = server
+        self.token = token
 
     def create_client(self):
         return client.ApiClient(self.api_client_config)

--- a/src/codeflare_sdk/cli/codeflare_cli.py
+++ b/src/codeflare_sdk/cli/codeflare_cli.py
@@ -5,6 +5,11 @@ import os
 cmd_folder = os.path.abspath(os.path.join(os.path.dirname(__file__), "commands"))
 
 
+class CodeflareContext:
+    def __init__(self, codeflare_path):
+        self.codeflare_path = codeflare_path
+
+
 class CodeflareCLI(click.MultiCommand):
     def list_commands(self, ctx):
         rv = []
@@ -26,9 +31,18 @@ class CodeflareCLI(click.MultiCommand):
             return
 
 
+def initialize_cli(ctx):
+    # Make .codeflare folder
+    codeflare_folder = os.path.expanduser("~/.codeflare")
+    if not os.path.exists(codeflare_folder):
+        os.makedirs(codeflare_folder)
+    ctx.obj = CodeflareContext(codeflare_folder)
+
+
 @click.command(cls=CodeflareCLI)
 @click.pass_context
 def cli(ctx):
+    initialize_cli(ctx)  # Ran on every command
     pass
 
 

--- a/src/codeflare_sdk/cli/commands/login.py
+++ b/src/codeflare_sdk/cli/commands/login.py
@@ -1,6 +1,7 @@
 import click
 import pickle
 from kubernetes import client
+import os
 
 from codeflare_sdk.cluster.auth import TokenAuthentication
 from codeflare_sdk.cli.cli_utils import AuthenticationConfig
@@ -8,6 +9,7 @@ import codeflare_sdk.cluster.auth as sdk_auth
 
 
 @click.command()
+@click.pass_context
 @click.option("--server", "-s", type=str, required=True, help="Cluster API address")
 @click.option("--token", "-t", type=str, required=True, help="Authentication token")
 @click.option(
@@ -21,7 +23,7 @@ import codeflare_sdk.cluster.auth as sdk_auth
     type=str,
     help="Path to cert file for certificate authority",
 )
-def cli(server, token, insecure_skip_tls_verify, certificate_authority):
+def cli(ctx, server, token, insecure_skip_tls_verify, certificate_authority):
     """
     Login to your Kubernetes cluster and save login for subsequent use
     """
@@ -32,12 +34,13 @@ def cli(server, token, insecure_skip_tls_verify, certificate_authority):
     if not sdk_auth.api_client:  # TokenAuthentication failed
         return
 
-    authConfig = AuthenticationConfig(
+    auth_config = AuthenticationConfig(
         token,
         server,
         insecure_skip_tls_verify,
         certificate_authority,
     )
-    with open("auth", "wb") as file:
-        pickle.dump(authConfig, file)
+    auth_file_path = ctx.obj.codeflare_path + "/auth"
+    with open(auth_file_path, "wb") as file:
+        pickle.dump(auth_config, file)
     click.echo(f"Logged into '{server}'")

--- a/src/codeflare_sdk/cli/commands/login.py
+++ b/src/codeflare_sdk/cli/commands/login.py
@@ -1,0 +1,28 @@
+import click
+import pickle
+
+from codeflare_sdk.cluster.auth import TokenAuthentication
+from codeflare_sdk.cli.cli_utils import AuthenticationConfig
+import codeflare_sdk.cluster.auth as sdk_auth
+
+
+@click.command()
+@click.argument("server")
+@click.option("--token", "-t", type=str, required=True)
+@click.option("--skip-tls", type=bool)
+@click.option("--ca-cert-path", type=str)
+def cli(server, token, skip_tls, ca_cert_path):
+    """
+    Login to your Kubernetes cluster by specifying server and token
+    """
+    try:
+        auth = TokenAuthentication(token, server, skip_tls, ca_cert_path)
+        auth.login()
+        authConfig = AuthenticationConfig(
+            token, server, skip_tls, ca_cert_path, sdk_auth.config_path
+        )
+        with open("auth", "wb") as file:
+            pickle.dump(authConfig, file)
+        click.echo(f"Logged into {server}")
+    except Exception as e:
+        click.echo(e)

--- a/src/codeflare_sdk/cli/commands/login.py
+++ b/src/codeflare_sdk/cli/commands/login.py
@@ -14,6 +14,7 @@ import codeflare_sdk.cluster.auth as sdk_auth
     "--insecure-skip-tls-verify",
     type=bool,
     help="If true, server's certificate won't be checked for validity",
+    default=False,
 )
 @click.option(
     "--certificate-authority",

--- a/src/codeflare_sdk/cli/commands/login.py
+++ b/src/codeflare_sdk/cli/commands/login.py
@@ -39,6 +39,6 @@ def cli(server, token, insecure_skip_tls_verify, certificate_authority):
         )
         with open("auth", "wb") as file:
             pickle.dump(authConfig, file)
-        click.echo(f"Logged into {server}")
+        click.echo(f"Logged into '{server}'")
     except Exception as e:
         click.echo(e)

--- a/src/codeflare_sdk/cli/commands/login.py
+++ b/src/codeflare_sdk/cli/commands/login.py
@@ -2,24 +2,40 @@ import click
 import pickle
 
 from codeflare_sdk.cluster.auth import TokenAuthentication
-from codeflare_sdk.cli.cli_utils import AuthenticationConfig
+from codeflare_sdk.cli.cli_utils import AuthenticationConfig, load_auth
 import codeflare_sdk.cluster.auth as sdk_auth
 
 
 @click.command()
-@click.argument("server")
-@click.option("--token", "-t", type=str, required=True)
-@click.option("--skip-tls", type=bool)
-@click.option("--ca-cert-path", type=str)
-def cli(server, token, skip_tls, ca_cert_path):
+@click.option("--server", type=str, required=True, help="Cluster API address")
+@click.option("--token", "-t", type=str, required=True, help="Authentication token")
+@click.option(
+    "--insecure-skip-tls-verify",
+    type=bool,
+    help="If true, server's certificate won't be checked for validity",
+)
+@click.option(
+    "--certificate-authority",
+    type=str,
+    help="Path to cert file for certificate authority",
+)
+def cli(server, token, insecure_skip_tls_verify, certificate_authority):
     """
-    Login to your Kubernetes cluster by specifying server and token
+    Login to your Kubernetes cluster and save login for subsequent use
     """
     try:
-        auth = TokenAuthentication(token, server, skip_tls, ca_cert_path)
+        auth = TokenAuthentication(
+            token, server, insecure_skip_tls_verify, certificate_authority
+        )
         auth.login()
+
+        # Store auth config for later use
         authConfig = AuthenticationConfig(
-            token, server, skip_tls, ca_cert_path, sdk_auth.config_path
+            token,
+            server,
+            insecure_skip_tls_verify,
+            certificate_authority,
+            sdk_auth.config_path,
         )
         with open("auth", "wb") as file:
             pickle.dump(authConfig, file)

--- a/src/codeflare_sdk/cli/commands/logout.py
+++ b/src/codeflare_sdk/cli/commands/logout.py
@@ -1,7 +1,6 @@
 import click
 import os
-
-from codeflare_sdk.cli.cli_utils import load_auth
+import pickle
 
 
 @click.command()
@@ -9,9 +8,10 @@ def cli():
     """
     Log out of current Kubernetes cluster
     """
-    auth = load_auth()
-    if not auth:
+    try:
+        with open("auth", "rb") as file:
+            auth = pickle.load(file)
+        os.remove("auth")
+        click.echo(f"Successfully logged out of '{auth.server}'")
+    except:
         click.echo("Not logged in")
-        return
-    os.remove("auth")
-    click.echo(f"Successfully logged out of '{auth.server}'")

--- a/src/codeflare_sdk/cli/commands/logout.py
+++ b/src/codeflare_sdk/cli/commands/logout.py
@@ -1,0 +1,17 @@
+import click
+import os
+
+from codeflare_sdk.cli.cli_utils import load_auth
+
+
+@click.command()
+def cli():
+    """
+    Log out of current Kubernetes cluster
+    """
+    auth = load_auth()
+    if not auth:
+        click.echo("Not logged in")
+        return
+    os.remove("auth")
+    click.echo(f"Logged out of '{auth.server}'")

--- a/src/codeflare_sdk/cli/commands/logout.py
+++ b/src/codeflare_sdk/cli/commands/logout.py
@@ -14,4 +14,4 @@ def cli():
         click.echo("Not logged in")
         return
     os.remove("auth")
-    click.echo(f"Logged out of '{auth.server}'")
+    click.echo(f"Successfully logged out of '{auth.server}'")

--- a/src/codeflare_sdk/cli/commands/logout.py
+++ b/src/codeflare_sdk/cli/commands/logout.py
@@ -4,14 +4,16 @@ import pickle
 
 
 @click.command()
-def cli():
+@click.pass_context
+def cli(ctx):
     """
     Log out of current Kubernetes cluster
     """
     try:
-        with open("auth", "rb") as file:
+        auth_file_path = ctx.obj.codeflare_path + "/auth"
+        with open(auth_file_path, "rb") as file:
             auth = pickle.load(file)
-        os.remove("auth")
+        os.remove(auth_file_path)
         click.echo(f"Successfully logged out of '{auth.server}'")
     except:
         click.echo("Not logged in")

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -97,17 +97,11 @@ class TokenAuthentication(Authentication):
         global config_path
         global api_client
         try:
-            configuration = client.Configuration()
-            configuration.api_key_prefix["authorization"] = "Bearer"
-            configuration.host = self.server
-            configuration.api_key["authorization"] = self.token
-            if self.skip_tls == False and self.ca_cert_path == None:
-                configuration.verify_ssl = True
-            elif self.skip_tls == False:
-                configuration.ssl_ca_cert = self.ca_cert_path
-            else:
-                configuration.verify_ssl = False
-            api_client = client.ApiClient(configuration)
+            api_client = client.ApiClient(
+                _create_api_client_config(
+                    self.token, self.server, self.skip_tls, self.ca_cert_path
+                )
+            )
             client.AuthenticationApi(api_client).get_api_group()
             config_path = None
             return "Logged into %s" % self.server
@@ -152,6 +146,22 @@ class KubeConfigFileAuthentication(KubeConfiguration):
             config_path = None
             raise Exception("Please specify a config file path")
         return response
+
+
+def _create_api_client_config(
+    token: str, server: str, skip_tls: bool = False, ca_cert_path: str = None
+):
+    configuration = client.Configuration()
+    configuration.api_key_prefix["authorization"] = "Bearer"
+    configuration.host = server
+    configuration.api_key["authorization"] = token
+    if skip_tls == False and ca_cert_path == None:
+        configuration.verify_ssl = True
+    elif skip_tls == False:
+        configuration.ssl_ca_cert = ca_cert_path
+    else:
+        configuration.verify_ssl = False
+    return configuration
 
 
 def config_check() -> str:

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -151,6 +151,9 @@ class KubeConfigFileAuthentication(KubeConfiguration):
 def _create_api_client_config(
     token: str, server: str, skip_tls: bool = False, ca_cert_path: str = None
 ):
+    """
+    Creates Kubernetes client configuration given necessary parameters
+    """
     configuration = client.Configuration()
     configuration.api_key_prefix["authorization"] = "Bearer"
     configuration.host = server

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -144,9 +144,6 @@ def test_login_tls_cli(mocker):
         tls_result.output == skip_tls_result.output == "Logged into 'testserver:6443'\n"
     )
 
-    # Clean up
-    os.remove("auth")
-
 
 # For mocking openshift client results
 fake_res = openshift.Result("fake")
@@ -2295,3 +2292,4 @@ def test_cleanup():
     os.remove("test.yaml")
     os.remove("raytest2.yaml")
     os.remove("cli-test-cluster.yaml")
+    os.remove("auth")

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -108,6 +108,46 @@ def test_cluster_definition_cli():
     )
 
 
+def test_login_logout_cli(mocker):
+    runner = CliRunner()
+    mocker.patch.object(client, "ApiClient")
+    k8s_login_command = """
+                        login
+                        --server=testserver:6443
+                        --token=testtoken
+                        """
+    login_result = runner.invoke(cli, k8s_login_command)
+    k8s_logout_command = "logout"
+    logout_result = runner.invoke(cli, k8s_logout_command)
+    assert login_result.output == "Logged into 'testserver:6443'\n"
+    assert logout_result.output == "Successfully logged out of 'testserver:6443'\n"
+
+
+def test_login_tls_cli(mocker):
+    runner = CliRunner()
+    mocker.patch.object(client, "ApiClient")
+    k8s_tls_login_command = """
+                        login
+                        --server=testserver:6443
+                        --token=testtoken
+                        --insecure-skip-tls-verify=False
+                        """
+    k8s_skip_tls_login_command = """
+                                login
+                                --server=testserver:6443
+                                --token=testtoken
+                                --insecure-skip-tls-verify=True
+                                """
+    tls_result = runner.invoke(cli, k8s_tls_login_command)
+    skip_tls_result = runner.invoke(cli, k8s_skip_tls_login_command)
+    assert (
+        tls_result.output == skip_tls_result.output == "Logged into 'testserver:6443'\n"
+    )
+
+    # Clean up
+    os.remove("auth")
+
+
 # For mocking openshift client results
 fake_res = openshift.Result("fake")
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -65,6 +65,8 @@ from codeflare_sdk.utils.generate_cert import (
     export_env,
 )
 from codeflare_sdk.cli.codeflare_cli import cli
+from codeflare_sdk.cli.cli_utils import load_auth
+import codeflare_sdk.cluster.auth as sdk_auth
 
 import openshift
 from openshift.selector import Selector
@@ -143,6 +145,11 @@ def test_login_tls_cli(mocker):
     assert (
         tls_result.output == skip_tls_result.output == "Logged into 'testserver:6443'\n"
     )
+
+
+def test_load_auth():
+    load_auth()
+    assert sdk_auth.api_client is not None
 
 
 # For mocking openshift client results


### PR DESCRIPTION
# Issue link
closes #217

# What changes have been made
Made login and logout functions in the CLI, allowing the user to authenticate into their Kubernetes cluster using token + server. Also added `load_auth` function which loads the authentication configuration so the SDK can use it.

# Verification steps
- `codeflare login` and `codeflare logout` are the two functions to be tested. Can be run in the terminal after building SDK with `pip install -e .`
- Unit tests can be run in usual way with `pytest -v tests/unit_test.py` or `python -m pytest tests/unit_test.py`

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
