### PR TITLE
cluster status safeguards

### DIFF
--- a/src/codeflare_sdk/cluster/model.py
+++ b/src/codeflare_sdk/cluster/model.py
@@ -39,6 +39,7 @@ class AppWrapperStatus(Enum):
     Defines the possible reportable states of an AppWrapper.
     """
 
+    QUEUEING = "queueing"
     PENDING = "pending"
     RUNNING = "running"
     FAILED = "failed"
@@ -55,8 +56,9 @@ class CodeFlareClusterStatus(Enum):
     READY = 1
     STARTING = 2
     QUEUED = 3
-    FAILED = 4
-    UNKNOWN = 5
+    QUEUEING = 4
+    FAILED = 5
+    UNKNOWN = 6
 
 
 @dataclass


### PR DESCRIPTION
# Issue link
#250 

# What changes have been made
Added error handling to prevent cluster.status/wait_ready crashes due to missing AW status

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
