### PR TITLE
Adjust main repo language to python

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-detectable=false


### PR DESCRIPTION
# Issue link
#245 

# What changes have been made
Changing the main language indicator on github.com from "Jupyter Notebook" to "Python"

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [x] Testing is not required for this change
