### PR TITLE
Fixed ingress domain methods

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -429,7 +429,7 @@ def get_cluster(cluster_name: str, namespace: str = "default"):
 def _get_ingress_domain():
     try:
         config.load_kube_config()
-        api_client = client.CustomObjectsApi()
+        api_client = client.CustomObjectsApi(api_config_handler())
         ingress = api_client.get_cluster_custom_object(
             "config.openshift.io", "v1", "ingresses", "cluster"
         )

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -23,6 +23,7 @@ import argparse
 import uuid
 from kubernetes import client, config
 from .kube_api_helpers import _kube_api_error_handling
+from ..cluster.auth import api_config_handler
 
 
 def read_template(template):
@@ -251,7 +252,7 @@ def enable_local_interactive(resources, cluster_name, namespace):
     command = command.replace("deployment-name", cluster_name)
     try:
         config.load_kube_config()
-        api_client = client.CustomObjectsApi()
+        api_client = client.CustomObjectsApi(api_config_handler())
         ingress = api_client.get_cluster_custom_object(
             "config.openshift.io", "v1", "ingresses", "cluster"
         )


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added the `api_config_handler()` method to `client.CustomObjectsApi` methods so that when a user authenticates with their token and password it uses their api instance.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Run `poetry build` in the codeflare folder from the terminal
* run `pip install dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl`
* From one of the guided demo Jupyter Notebooks
* log in with token + server
* Create a local interactive cluster config by setting `local_interactive = True`
* run `cluster.up()`
* run `cluster.local_client_url()`
You should receive a url similar to this...
`ray://rayclient-<"cluster-name">-<"namespace">.<"domain">`
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
