### PR TITLE
Force install pydantic module below v2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ kubernetes = ">= 25.3.0, < 27"
 codeflare-torchx = "0.6.0.dev0"
 cryptography = "40.0.2"
 executing = "1.2.0"
+pydantic = "< 2"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
# Issue link
https://github.com/project-codeflare/codeflare-sdk/issues/223

# What changes have been made
Add pydantic<2 into the pyproject.toml file

# Verification steps
## First Download the branch with the PR
```sh
git clone --single-branch --branch issue-223 https://github.com/tedhtchang/codeflare-sdk.git
cd codeflare-sdk/
```

## Build and install a new wheel for codeflare-sdk module
```sh
poetry build
pip install -U dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl
```
## Verify pydantic version is below 2
```sh
pip list |grep pydantic 
```

```
# should be something like:
pydantic                  1.10.12
pydantic_core             2.4.0
```
## Test the ray.init()
Run the jupyter notebook from your laptop.
```sh
# pip install jupyterlab
jupyter lab demo-notebooks/interactive/local_interactive.ipynb
```
Make sure `ray.init(address=cluster.local_client_url(), logging_level="DEBUG")` does not fail with `AttributeError: module 'pydantic.fields' has no attribute 'ModelField'` error.


## Checks
- [ x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x ] Manual tests
   - [ ] Testing is not required for this change
