### PR TITLE
Added in cluster configuration support

### DIFF
--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -162,7 +162,14 @@ def config_check() -> str:
     global config_path
     global api_client
     if config_path == None and api_client == None:
-        config.load_kube_config()
+        try:
+            config.load_kube_config()
+        except config.config_exception.ConfigException:
+            try:
+                config.load_incluster_config()
+            except:
+                print("Unable to load config file or in cluster configuration")
+
     if config_path != None and api_client == None:
         return config_path
 

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -21,6 +21,7 @@ authenticate to their cluster or add their own custom concrete classes here.
 
 import abc
 from kubernetes import client, config
+import os
 
 global api_client
 api_client = None
@@ -161,14 +162,16 @@ def config_check() -> str:
     """
     global config_path
     global api_client
+    home_directory = os.path.expanduser("~")
     if config_path == None and api_client == None:
-        try:
+        if os.path.isfile("%s/.kube/config" % home_directory):
             config.load_kube_config()
-        except config.config_exception.ConfigException:
-            try:
-                config.load_incluster_config()
-            except:
-                print("Unable to load config file or in cluster configuration")
+        elif "KUBERNETES_PORT" in os.environ:
+            config.load_incluster_config()
+        else:
+            print(
+                "Unable to load config file or in cluster configuration, try specifying a config file path with load_kube_config()"
+            )
 
     if config_path != None and api_client == None:
         return config_path

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -167,12 +167,12 @@ def config_check() -> str:
         if os.path.isfile("%s/.kube/config" % home_directory):
             try:
                 config.load_kube_config()
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 print(e)
         elif "KUBERNETES_PORT" in os.environ:
             try:
                 config.load_incluster_config()
-            except Exception as e:
+            except Exception as e:  # pragma: no cover
                 print(e)
         else:
             raise PermissionError(

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -165,12 +165,18 @@ def config_check() -> str:
     home_directory = os.path.expanduser("~")
     if config_path == None and api_client == None:
         if os.path.isfile("%s/.kube/config" % home_directory):
-            config.load_kube_config()
+            try:
+                config.load_kube_config()
+            except Exception as e:
+                print(e)
         elif "KUBERNETES_PORT" in os.environ:
-            config.load_incluster_config()
+            try:
+                config.load_incluster_config()
+            except Exception as e:
+                print(e)
         else:
-            print(
-                "Unable to load config file or in cluster configuration, try specifying a config file path with load_kube_config()"
+            raise PermissionError(
+                "Action not permitted, have you put in correct/up-to-date auth credentials?"
             )
 
     if config_path != None and api_client == None:

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -22,6 +22,7 @@ authenticate to their cluster or add their own custom concrete classes here.
 import abc
 from kubernetes import client, config
 import os
+from ..utils.kube_api_helpers import _kube_api_error_handling
 
 global api_client
 api_client = None
@@ -168,12 +169,12 @@ def config_check() -> str:
             try:
                 config.load_kube_config()
             except Exception as e:  # pragma: no cover
-                print(e)
+                _kube_api_error_handling(e)
         elif "KUBERNETES_PORT" in os.environ:
             try:
                 config.load_incluster_config()
             except Exception as e:  # pragma: no cover
-                print(e)
+                _kube_api_error_handling(e)
         else:
             raise PermissionError(
                 "Action not permitted, have you put in correct/up-to-date auth credentials?"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
Closes #255
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Changed the config check method to load the config file first and if it doesn't work it will try load the in cluster configuration.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* From the terminal run in the codeflare-sdk directory `poetry build`
* In a cluster go to the Open Datahub dashboard 
* Create a codeflare Jupytr notebook 
* uninstall the current codeflare-sdk with `pip uninstall codeflare-sdk -y`
* Drag and drop the build into the Jupyter notebook
* Install the build with `pip install codeflare_sdk-0.0.0.dev0-py3-none-any.whl`
* Restart the Notebook kernel 
* Run through a demo notebook without logging in with token + server (This is important because it affects how config files are loaded)
* `cluster.up()` should work without a kubernetes config file and default to using the `incluster_config`
## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
