### PR TITLE
CLI Define and Submit job commands

### DIFF
--- a/src/codeflare_sdk/cli/codeflare_cli.py
+++ b/src/codeflare_sdk/cli/codeflare_cli.py
@@ -44,7 +44,8 @@ class CodeflareCLI(click.MultiCommand):
 @click.command(cls=CodeflareCLI)
 @click.pass_context
 def cli(ctx):
-    load_auth()
+    if ctx.invoked_subcommand != "login":
+        load_auth()
     ctx.obj = CodeflareContext()  # Ran on every command
     pass
 

--- a/src/codeflare_sdk/cli/codeflare_cli.py
+++ b/src/codeflare_sdk/cli/codeflare_cli.py
@@ -44,7 +44,7 @@ class CodeflareCLI(click.MultiCommand):
 @click.command(cls=CodeflareCLI)
 @click.pass_context
 def cli(ctx):
-    if ctx.invoked_subcommand != "login":
+    if ctx.invoked_subcommand != "login" and ctx.invoked_subcommand != "logout":
         load_auth()
     ctx.obj = CodeflareContext()  # Ran on every command
     pass

--- a/src/codeflare_sdk/cli/commands/define.py
+++ b/src/codeflare_sdk/cli/commands/define.py
@@ -43,10 +43,10 @@ def raycluster(ctx, **kwargs):
 
 @cli.command()
 @click.pass_context
-@click.option("--script", type=str)
+@click.option("--script", type=str, required=True)
 @click.option("--m", type=str)
 @click.option("--script-args", cls=PythonLiteralOption, type=list)
-@click.option("--name", type=str)
+@click.option("--name", type=str, required=True)
 @click.option("--cpu", type=int)
 @click.option("--gpu", type=int)
 @click.option("--memMB", type=int)

--- a/src/codeflare_sdk/cli/commands/define.py
+++ b/src/codeflare_sdk/cli/commands/define.py
@@ -57,7 +57,7 @@ def raycluster(ctx, **kwargs):
 @click.option("--mounts", cls=PythonLiteralOption, type=list)
 @click.option("--rdzv-port", type=int)
 @click.option("--rdzv-backend", type=str)
-@click.option("--schedular-args", cls=PythonLiteralOption, type=dict)
+@click.option("--scheduler-args", cls=PythonLiteralOption, type=dict)
 @click.option("--image", type=str)
 @click.option("--workspace", type=str)
 def job(ctx, **kwargs):

--- a/src/codeflare_sdk/cli/commands/define.py
+++ b/src/codeflare_sdk/cli/commands/define.py
@@ -1,8 +1,10 @@
 import click
+import pickle
 
 from codeflare_sdk.cluster.cluster import Cluster
 from codeflare_sdk.cluster.config import ClusterConfiguration
 from codeflare_sdk.cli.cli_utils import PythonLiteralOption
+from codeflare_sdk.job.jobs import DDPJobDefinition
 
 
 @click.group()
@@ -15,21 +17,21 @@ def cli():
 @click.pass_context
 @click.option("--name", type=str, required=True)
 @click.option("--namespace", "-n", type=str)
-@click.option("--head_info", cls=PythonLiteralOption, type=list)
-@click.option("--machine_types", cls=PythonLiteralOption, type=list)
-@click.option("--min_cpus", type=int)
-@click.option("--max_cpus", type=int)
-@click.option("--min_worker", type=int)
-@click.option("--max_worker", type=int)
-@click.option("--min_memory", type=int)
-@click.option("--max_memory", type=int)
+@click.option("--head-info", cls=PythonLiteralOption, type=list)
+@click.option("--machine-types", cls=PythonLiteralOption, type=list)
+@click.option("--min-cpus", type=int)
+@click.option("--max-cpus", type=int)
+@click.option("--min-worker", type=int)
+@click.option("--max-worker", type=int)
+@click.option("--min-memory", type=int)
+@click.option("--max-memory", type=int)
 @click.option("--gpu", type=int)
 @click.option("--template", type=str)
 @click.option("--instascale", type=bool)
 @click.option("--envs", cls=PythonLiteralOption, type=dict)
 @click.option("--image", type=str)
-@click.option("--local_interactive", type=bool)
-@click.option("--image_pull_secrets", cls=PythonLiteralOption, type=list)
+@click.option("--local-interactive", type=bool)
+@click.option("--image-pull-secrets", cls=PythonLiteralOption, type=list)
 def raycluster(ctx, **kwargs):
     """Define a RayCluster with parameter specifications"""
     filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
@@ -37,3 +39,35 @@ def raycluster(ctx, **kwargs):
         filtered_kwargs["namespace"] = ctx.obj.current_namespace
     clusterConfig = ClusterConfiguration(**filtered_kwargs)
     Cluster(clusterConfig)  # Creates yaml file
+
+
+@cli.command()
+@click.pass_context
+@click.option("--script", type=str)
+@click.option("--m", type=str)
+@click.option("--script-args", cls=PythonLiteralOption, type=list)
+@click.option("--name", type=str)
+@click.option("--cpu", type=int)
+@click.option("--gpu", type=int)
+@click.option("--memMB", type=int)
+@click.option("--h", type=str)
+@click.option("--j", type=str)
+@click.option("--env", cls=PythonLiteralOption, type=dict)
+@click.option("--max-retries", type=int)
+@click.option("--mounts", cls=PythonLiteralOption, type=list)
+@click.option("--rdzv-port", type=int)
+@click.option("--rdzv-backend", type=str)
+@click.option("--schedular-args", cls=PythonLiteralOption, type=dict)
+@click.option("--image", type=str)
+@click.option("--workspace", type=str)
+def job(ctx, **kwargs):
+    """Define a job with specified resources"""
+    filtered_kwargs = {k: v for k, v in kwargs.items() if v is not None}
+    if "memmb" in filtered_kwargs:
+        filtered_kwargs["memMB"] = filtered_kwargs["memmb"]
+        del filtered_kwargs["memmb"]
+    job_def = DDPJobDefinition(**filtered_kwargs)
+    job_file_path = ctx.obj.codeflare_path + f"/{job_def.name}"
+    with open(job_file_path, "wb") as file:
+        pickle.dump(job_def, file)
+    click.echo("Job definition saved to " + job_file_path)

--- a/src/codeflare_sdk/cli/commands/login.py
+++ b/src/codeflare_sdk/cli/commands/login.py
@@ -25,7 +25,7 @@ import codeflare_sdk.cluster.auth as sdk_auth
 )
 def cli(ctx, server, token, insecure_skip_tls_verify, certificate_authority):
     """
-    Login to your Kubernetes cluster and save login for subsequent use
+    Login to your Kubernetes cluster and save login for later use
     """
     auth = TokenAuthentication(
         token, server, insecure_skip_tls_verify, certificate_authority

--- a/src/codeflare_sdk/cli/commands/submit.py
+++ b/src/codeflare_sdk/cli/commands/submit.py
@@ -58,12 +58,17 @@ def job(ctx, name, cluster_name, namespace):
     if not cluster_name:
         job = job_def.submit()
         submission_id = runner.describe(job._app_handle).name.split(":")[1]
-        click.echo(f"{submission_id} submitted successfully")
+        click.echo(f"Job {submission_id} submitted successfully")
         return
-    cluster = get_cluster(cluster_name, namespace or ctx.obj.current_namespace)
+    namespace = namespace or ctx.obj.current_namespace
+    try:
+        cluster = get_cluster(cluster_name, namespace)
+    except FileNotFoundError:
+        click.echo(f"Cluster {name} not found in {namespace} namespace")
+        return
     job = job_def.submit(cluster)
     full_name = runner.describe(job._app_handle).name
     submission_id = full_name[full_name.rfind(name) :]
     click.echo(
-        f"{submission_id} submitted onto {cluster_name} RayCluster successfully\nView dashboard: {cluster.cluster_dashboard_uri()}"
+        f"Job {submission_id} submitted onto {cluster_name} RayCluster successfully\nView dashboard: {cluster.cluster_dashboard_uri()}"
     )

--- a/src/codeflare_sdk/cli/commands/submit.py
+++ b/src/codeflare_sdk/cli/commands/submit.py
@@ -40,7 +40,7 @@ def raycluster(name, wait):
 @click.pass_context
 @click.argument("name", type=str)
 @click.option("--cluster-name", type=str)
-@click.option("--namespace", type=str, required=True)
+@click.option("--namespace", type=str)
 def job(ctx, name, cluster_name, namespace):
     """
     Submit a defined job to the Kubernetes cluster or a RayCluster
@@ -60,7 +60,7 @@ def job(ctx, name, cluster_name, namespace):
         submission_id = runner.describe(job._app_handle).name.split(":")[1]
         click.echo(f"{submission_id} submitted successfully")
         return
-    cluster = get_cluster(cluster_name, namespace)
+    cluster = get_cluster(cluster_name, namespace or ctx.obj.current_namespace)
     job = job_def.submit(cluster)
     full_name = runner.describe(job._app_handle).name
     submission_id = full_name[full_name.rfind(name) :]

--- a/src/codeflare_sdk/cli/commands/submit.py
+++ b/src/codeflare_sdk/cli/commands/submit.py
@@ -1,4 +1,5 @@
 import click
+import os
 
 from codeflare_sdk.cluster.cluster import Cluster
 import pickle
@@ -46,15 +47,14 @@ def job(ctx, name, cluster_name, namespace):
     Submit a defined job to the Kubernetes cluster or a RayCluster
     """
     runner = get_runner()
-    try:
-        job_path = ctx.obj.codeflare_path + f"/{name}"
-        with open(job_path, "rb") as file:
-            job_def = pickle.load(file)
-    except Exception as e:
+    job_path = ctx.obj.codeflare_path + f"/{name}"
+    if not os.path.isfile(job_path):
         click.echo(
             f"Error submitting job. Make sure the job is defined before submitting it"
         )
         return
+    with open(job_path, "rb") as file:
+        job_def = pickle.load(file)
     if not cluster_name:
         job = job_def.submit()
         submission_id = runner.describe(job._app_handle).name.split(":")[1]

--- a/src/codeflare_sdk/cli/commands/submit.py
+++ b/src/codeflare_sdk/cli/commands/submit.py
@@ -1,6 +1,10 @@
 import click
 
 from codeflare_sdk.cluster.cluster import Cluster
+import pickle
+from torchx.runner import get_runner
+
+from codeflare_sdk.cluster.cluster import get_cluster
 
 
 @click.group()
@@ -30,3 +34,36 @@ def raycluster(name, wait):
         return
     cluster.up()
     cluster.wait_ready()
+
+
+@cli.command()
+@click.pass_context
+@click.argument("name", type=str)
+@click.option("--cluster-name", type=str)
+@click.option("--namespace", type=str, required=True)
+def job(ctx, name, cluster_name, namespace):
+    """
+    Submit a defined job to the Kubernetes cluster or a RayCluster
+    """
+    runner = get_runner()
+    try:
+        job_path = ctx.obj.codeflare_path + f"/{name}"
+        with open(job_path, "rb") as file:
+            job_def = pickle.load(file)
+    except Exception as e:
+        click.echo(
+            f"Error submitting job. Make sure the job is defined before submitting it"
+        )
+        return
+    if not cluster_name:
+        job = job_def.submit()
+        submission_id = runner.describe(job._app_handle).name.split(":")[1]
+        click.echo(f"{submission_id} submitted successfully")
+        return
+    cluster = get_cluster(cluster_name, namespace)
+    job = job_def.submit(cluster)
+    full_name = runner.describe(job._app_handle).name
+    submission_id = full_name[full_name.rfind(name) :]
+    click.echo(
+        f"{submission_id} submitted onto {cluster_name} RayCluster successfully\nView dashboard: {cluster.cluster_dashboard_uri()}"
+    )


### PR DESCRIPTION
# Issue link
closes #276 

# What changes have been made
`define job` and `submit job` commands. Allows user to define and submit jobs from the terminal
- `codeflare define job` takes in the same parameters that the SDK defines and creates a DDPJobDefinition in the user's .codeflare folder. 
- `codeflare submit job` submits a job based on the job name. The user can either submit to a raycluster or just to k8s. 

# Verification steps
- After building SDK, tester can run `codeflare submit job --help` or `codeflare define job --help` to see how each command works and then can run each command
- Unit tests can be run with `pytest -v tests/unit_test.py`

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
