### PR TITLE
fix get_current_namespace

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -442,29 +442,21 @@ def list_all_queued(namespace: str, print_to_console: bool = True):
 
 
 def get_current_namespace():  # pragma: no cover
-    if api_config_handler() != None:
-        if os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"):
-            try:
-                file = open(
-                    "/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r"
-                )
-                active_context = file.readline().strip("\n")
-                return active_context
-            except Exception as e:
-                print("Unable to find current namespace")
-                return None
-        else:
-            print("Unable to find current namespace")
-            return None
-    else:
+    if os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"):
         try:
-            _, active_context = config.list_kube_config_contexts(config_check())
+            file = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r")
+            active_context = file.readline().strip("\n")
+            return active_context
         except Exception as e:
-            return _kube_api_error_handling(e)
-        try:
-            return active_context["context"]["namespace"]
-        except KeyError:
-            return None
+            pass
+    try:
+        _, active_context = config.list_kube_config_contexts(config_check())
+    except Exception as e:
+        return _kube_api_error_handling(e)
+    try:
+        return active_context["context"]["namespace"]
+    except KeyError:
+        return None
 
 
 def get_cluster(cluster_name: str, namespace: str = "default"):


### PR DESCRIPTION
# Issue link
closes #289 

# What changes have been made
- `get_current_namespace` checks both serviceaccount and kubeconfig for current namespace. Removed `api_config_handler` check because sometimes you have `api_client` but want to check kubeconfig instead of serviceaccount.

# Verification steps
- Try logging in with `TokenAuthentication` after calling `oc logout` and call `get_current_namespace`. This will give you your current namespace. If you do this on the old `get_current_namespace` it will say namespace not found.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
