### PR TITLE
add and implement option to not generate appwrapper in a Cluster

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -120,8 +120,8 @@ class Cluster:
         the MCAD queue.
         """
         if self.app_wrapper_yaml is None:
-            print("Error putting up RayCluster: AppWrapper yaml not generated")
-            return
+            self.app_wrapper_yaml = self.create_app_wrapper()
+            self.app_wrapper_name = self.app_wrapper_yaml.split(".")[0]
         namespace = self.config.namespace
         try:
             config_check()
@@ -144,6 +144,9 @@ class Cluster:
         associated with the cluster.
         """
         namespace = self.config.namespace
+        if not self.config.name and not self.app_wrapper_name:
+            print("Error taking down cluster: missing name or AppWrapper")
+            return
         try:
             config_check()
             api_instance = client.CustomObjectsApi(api_config_handler())
@@ -152,7 +155,7 @@ class Cluster:
                 version="v1beta1",
                 namespace=namespace,
                 plural="appwrappers",
-                name=self.config.name,
+                name=self.app_wrapper_name or self.config.name,
             )
         except Exception as e:  # pragma: no cover
             return _kube_api_error_handling(e)

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -50,7 +50,7 @@ class Cluster:
 
     torchx_scheduler = "ray"
 
-    def __init__(self, config: ClusterConfiguration):
+    def __init__(self, config: ClusterConfiguration, generate_app_wrapper: bool = True):
         """
         Create the resource cluster object by passing in a ClusterConfiguration
         (defined in the config sub-module). An AppWrapper will then be generated
@@ -58,13 +58,17 @@ class Cluster:
         request.
         """
         self.config = config
-        self.app_wrapper_yaml = self.create_app_wrapper()
-        self.app_wrapper_name = self.app_wrapper_yaml.split(".")[0]
+        self.app_wrapper_yaml = None
+        self.app_wrapper_name = None
+
+        if generate_app_wrapper:
+            self.app_wrapper_yaml = self.create_app_wrapper()
+            self.app_wrapper_name = self.app_wrapper_yaml.split(".")[0]
 
     def create_app_wrapper(self):
         """
-        Called upon cluster object creation, creates an AppWrapper yaml based on
-        the specifications of the ClusterConfiguration.
+        Called upon cluster object creation if generate_app_wrapper is True, creates an AppWrapper yaml
+        based on the specifications of the ClusterConfiguration.
         """
 
         if self.config.namespace is None:
@@ -115,6 +119,9 @@ class Cluster:
         Applies the AppWrapper yaml, pushing the resource request onto
         the MCAD queue.
         """
+        if self.app_wrapper_yaml is None:
+            print("Error putting up RayCluster: AppWrapper yaml not generated")
+            return
         namespace = self.config.namespace
         try:
             config_check()
@@ -145,7 +152,7 @@ class Cluster:
                 version="v1beta1",
                 namespace=namespace,
                 plural="appwrappers",
-                name=self.app_wrapper_name,
+                name=self.config.name,
             )
         except Exception as e:  # pragma: no cover
             return _kube_api_error_handling(e)
@@ -346,7 +353,7 @@ class Cluster:
             ]["image"],
             local_interactive=local_interactive,
         )
-        return Cluster(cluster_config)
+        return Cluster(cluster_config, False)
 
     def from_definition_yaml(yaml_path):
         try:

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -67,7 +67,7 @@ class Cluster:
 
     def create_app_wrapper(self):
         """
-        Called upon cluster object creation if generate_app_wrapper is True, creates an AppWrapper yaml
+        Creates an AppWrapper yaml based on the specified cluster config
         based on the specifications of the ClusterConfiguration.
         """
 

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -2518,7 +2518,6 @@ def test_cleanup():
     os.remove("unit-test-default-cluster.yaml")
     os.remove("test.yaml")
     os.remove("raytest2.yaml")
-    os.remove("quicktest.yaml")
     os.remove("tls-cluster-namespace/ca.crt")
     os.remove("tls-cluster-namespace/tls.crt")
     os.remove("tls-cluster-namespace/tls.key")


### PR DESCRIPTION
# Issue link
Closes #278 

# What changes have been made
Changed Cluster definition so it optionally doesn't create an appwrapper. Changed `Cluster.from_k8_cluster_object` so it doesn't create an appwrapper. So when `get_cluster` is called, no appwrapper is generated

# Verification steps
Use `get_cluster` and it won't generate an appwrapper. Use Cluster object normally and it will. 

## Checks
- [x]  I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
