### PR TITLE
add functions for creating ray with oauth proxy in front of the dashboard

### DIFF
--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -25,6 +25,8 @@ import os
 import urllib3
 from ..utils.kube_api_helpers import _kube_api_error_handling
 
+from typing import Optional
+
 global api_client
 api_client = None
 global config_path
@@ -188,7 +190,7 @@ def config_check() -> str:
         return config_path
 
 
-def api_config_handler() -> str:
+def api_config_handler() -> Optional[client.ApiClient]:
     """
     This function is used to load the api client if the user has logged in
     """

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -33,7 +33,6 @@ from ..utils.kube_api_helpers import _kube_api_error_handling
 from ..utils.openshift_oauth import (
     create_openshift_oauth_objects,
     delete_openshift_oauth_objects,
-    download_tls_cert,
 )
 from .config import ClusterConfiguration
 from .model import (

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -51,3 +51,4 @@ class ClusterConfiguration:
     local_interactive: bool = False
     image_pull_secrets: list = field(default_factory=list)
     dispatch_priority: str = None
+    openshift_oauth: bool = False  # NOTE: to use the user must have permission to create a RoleBinding for system:auth-delegator

--- a/src/codeflare_sdk/job/jobs.py
+++ b/src/codeflare_sdk/job/jobs.py
@@ -18,15 +18,20 @@ from typing import TYPE_CHECKING, Optional, Dict, List
 from pathlib import Path
 
 from torchx.components.dist import ddp
-from torchx.runner import get_runner
+from torchx.runner import get_runner, Runner
+from torchx.schedulers.ray_scheduler import RayScheduler
 from torchx.specs import AppHandle, parse_app_handle, AppDryRunInfo
+
+from ray.job_submission import JobSubmissionClient
+
+import openshift as oc
 
 if TYPE_CHECKING:
     from ..cluster.cluster import Cluster
 from ..cluster.cluster import get_current_namespace
+from ..utils.openshift_oauth import download_tls_cert
 
 all_jobs: List["Job"] = []
-torchx_runner = get_runner()
 
 
 class JobDefinition(metaclass=abc.ABCMeta):
@@ -92,30 +97,37 @@ class DDPJobDefinition(JobDefinition):
 
     def _dry_run(self, cluster: "Cluster"):
         j = f"{cluster.config.num_workers}x{max(cluster.config.num_gpus, 1)}"  # # of proc. = # of gpus
-        return torchx_runner.dryrun(
-            app=ddp(
-                *self.script_args,
-                script=self.script,
-                m=self.m,
-                name=self.name,
-                h=self.h,
-                cpu=self.cpu if self.cpu is not None else cluster.config.max_cpus,
-                gpu=self.gpu if self.gpu is not None else cluster.config.num_gpus,
-                memMB=self.memMB
-                if self.memMB is not None
-                else cluster.config.max_memory * 1024,
-                j=self.j if self.j is not None else j,
-                env=self.env,
-                max_retries=self.max_retries,
-                rdzv_port=self.rdzv_port,
-                rdzv_backend=self.rdzv_backend
-                if self.rdzv_backend is not None
-                else "static",
-                mounts=self.mounts,
+        runner = get_runner(ray_client=cluster.client)
+        runner._scheduler_instances["ray"] = RayScheduler(
+            session_name=runner._name, ray_client=cluster.client
+        )
+        return (
+            runner.dryrun(
+                app=ddp(
+                    *self.script_args,
+                    script=self.script,
+                    m=self.m,
+                    name=self.name,
+                    h=self.h,
+                    cpu=self.cpu if self.cpu is not None else cluster.config.max_cpus,
+                    gpu=self.gpu if self.gpu is not None else cluster.config.num_gpus,
+                    memMB=self.memMB
+                    if self.memMB is not None
+                    else cluster.config.max_memory * 1024,
+                    j=self.j if self.j is not None else j,
+                    env=self.env,
+                    max_retries=self.max_retries,
+                    rdzv_port=self.rdzv_port,
+                    rdzv_backend=self.rdzv_backend
+                    if self.rdzv_backend is not None
+                    else "static",
+                    mounts=self.mounts,
+                ),
+                scheduler=cluster.torchx_scheduler,
+                cfg=cluster.torchx_config(**self.scheduler_args),
+                workspace=self.workspace,
             ),
-            scheduler=cluster.torchx_scheduler,
-            cfg=cluster.torchx_config(**self.scheduler_args),
-            workspace=self.workspace,
+            runner,
         )
 
     def _missing_spec(self, spec: str):
@@ -125,41 +137,47 @@ class DDPJobDefinition(JobDefinition):
         if self.scheduler_args is not None:
             if self.scheduler_args.get("namespace") is None:
                 self.scheduler_args["namespace"] = get_current_namespace()
-        return torchx_runner.dryrun(
-            app=ddp(
-                *self.script_args,
-                script=self.script,
-                m=self.m,
-                name=self.name if self.name is not None else self._missing_spec("name"),
-                h=self.h,
-                cpu=self.cpu
-                if self.cpu is not None
-                else self._missing_spec("cpu (# cpus per worker)"),
-                gpu=self.gpu
-                if self.gpu is not None
-                else self._missing_spec("gpu (# gpus per worker)"),
-                memMB=self.memMB
-                if self.memMB is not None
-                else self._missing_spec("memMB (memory in MB)"),
-                j=self.j
-                if self.j is not None
-                else self._missing_spec(
-                    "j (`workers`x`procs`)"
-                ),  # # of proc. = # of gpus,
-                env=self.env,  # should this still exist?
-                max_retries=self.max_retries,
-                rdzv_port=self.rdzv_port,  # should this still exist?
-                rdzv_backend=self.rdzv_backend
-                if self.rdzv_backend is not None
-                else "c10d",
-                mounts=self.mounts,
-                image=self.image
-                if self.image is not None
-                else self._missing_spec("image"),
+        runner = get_runner()
+        return (
+            runner.dryrun(
+                app=ddp(
+                    *self.script_args,
+                    script=self.script,
+                    m=self.m,
+                    name=self.name
+                    if self.name is not None
+                    else self._missing_spec("name"),
+                    h=self.h,
+                    cpu=self.cpu
+                    if self.cpu is not None
+                    else self._missing_spec("cpu (# cpus per worker)"),
+                    gpu=self.gpu
+                    if self.gpu is not None
+                    else self._missing_spec("gpu (# gpus per worker)"),
+                    memMB=self.memMB
+                    if self.memMB is not None
+                    else self._missing_spec("memMB (memory in MB)"),
+                    j=self.j
+                    if self.j is not None
+                    else self._missing_spec(
+                        "j (`workers`x`procs`)"
+                    ),  # # of proc. = # of gpus,
+                    env=self.env,  # should this still exist?
+                    max_retries=self.max_retries,
+                    rdzv_port=self.rdzv_port,  # should this still exist?
+                    rdzv_backend=self.rdzv_backend
+                    if self.rdzv_backend is not None
+                    else "c10d",
+                    mounts=self.mounts,
+                    image=self.image
+                    if self.image is not None
+                    else self._missing_spec("image"),
+                ),
+                scheduler="kubernetes_mcad",
+                cfg=self.scheduler_args,
+                workspace="",
             ),
-            scheduler="kubernetes_mcad",
-            cfg=self.scheduler_args,
-            workspace="",
+            runner,
         )
 
     def submit(self, cluster: "Cluster" = None) -> "Job":
@@ -171,18 +189,20 @@ class DDPJob(Job):
         self.job_definition = job_definition
         self.cluster = cluster
         if self.cluster:
-            self._app_handle = torchx_runner.schedule(job_definition._dry_run(cluster))
+            definition, runner = job_definition._dry_run(cluster)
+            self._app_handle = runner.schedule(definition)
+            self._runner = runner
         else:
-            self._app_handle = torchx_runner.schedule(
-                job_definition._dry_run_no_cluster()
-            )
+            definition, runner = job_definition._dry_run_no_cluster()
+            self._app_handle = runner.schedule(definition)
+            self._runner = runner
         all_jobs.append(self)
 
     def status(self) -> str:
-        return torchx_runner.status(self._app_handle)
+        return self._runner.status(self._app_handle)
 
     def logs(self) -> str:
-        return "".join(torchx_runner.log_lines(self._app_handle, None))
+        return "".join(self._runner.log_lines(self._app_handle, None))
 
     def cancel(self):
-        torchx_runner.cancel(self._app_handle)
+        self._runner.cancel(self._app_handle)

--- a/src/codeflare_sdk/job/jobs.py
+++ b/src/codeflare_sdk/job/jobs.py
@@ -29,7 +29,6 @@ import openshift as oc
 if TYPE_CHECKING:
     from ..cluster.cluster import Cluster
 from ..cluster.cluster import get_current_namespace
-from ..utils.openshift_oauth import download_tls_cert
 
 all_jobs: List["Job"] = []
 

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -24,6 +24,11 @@ import uuid
 from kubernetes import client, config
 from .kube_api_helpers import _kube_api_error_handling
 from ..cluster.auth import api_config_handler, config_check
+from os import urandom
+from base64 import b64encode
+from urllib3.util import parse_url
+
+from kubernetes import client, config
 
 
 def read_template(template):
@@ -46,11 +51,15 @@ def gen_names(name):
 
 def update_dashboard_route(route_item, cluster_name, namespace):
     metadata = route_item.get("generictemplate", {}).get("metadata")
-    metadata["name"] = f"ray-dashboard-{cluster_name}"
+    metadata["name"] = gen_dashboard_route_name(cluster_name)
     metadata["namespace"] = namespace
     metadata["labels"]["odh-ray-cluster-service"] = f"{cluster_name}-head-svc"
     spec = route_item.get("generictemplate", {}).get("spec")
     spec["to"]["name"] = f"{cluster_name}-head-svc"
+
+
+def gen_dashboard_route_name(cluster_name):
+    return f"ray-dashboard-{cluster_name}"
 
 
 # ToDo: refactor the update_x_route() functions
@@ -369,6 +378,83 @@ def write_user_appwrapper(user_yaml, output_file_name):
     print(f"Written to: {output_file_name}")
 
 
+def enable_openshift_oauth(user_yaml, cluster_name, namespace):
+    config_check()
+    k8_client = api_config_handler()
+    tls_mount_location = "/etc/tls/private"
+    oauth_port = 8443
+    oauth_sa_name = f"{cluster_name}-oauth-proxy"
+    tls_secret_name = f"{cluster_name}-proxy-tls-secret"
+    tls_volume_name = "proxy-tls-secret"
+    port_name = "oauth-proxy"
+    _, _, host, _, _, _, _ = parse_url(k8_client.configuration.host)
+    host = host.replace(
+        "api.", f"{gen_dashboard_route_name(cluster_name)}-{namespace}.apps."
+    )
+    oauth_sidecar = _create_oauth_sidecar_object(
+        namespace,
+        tls_mount_location,
+        oauth_port,
+        oauth_sa_name,
+        tls_volume_name,
+        port_name,
+    )
+    tls_secret_volume = client.V1Volume(
+        name=tls_volume_name,
+        secret=client.V1SecretVolumeSource(secret_name=tls_secret_name),
+    )
+    # allows for setting value of Cluster object when initializing object from an existing AppWrapper on cluster
+    user_yaml["metadata"]["annotations"] = user_yaml["metadata"].get("annotations", {})
+    user_yaml["metadata"]["annotations"][
+        "codeflare-sdk-use-oauth"
+    ] = "true"  # if the user gets an
+    ray_headgroup_pod = user_yaml["spec"]["resources"]["GenericItems"][0][
+        "generictemplate"
+    ]["spec"]["headGroupSpec"]["template"]["spec"]
+    user_yaml["spec"]["resources"]["GenericItems"].pop(1)
+    ray_headgroup_pod["serviceAccount"] = oauth_sa_name
+    ray_headgroup_pod["volumes"] = ray_headgroup_pod.get("volumes", [])
+    ray_headgroup_pod["volumes"].append(
+        k8_client.sanitize_for_serialization(tls_secret_volume)
+    )
+    ray_headgroup_pod["containers"].append(
+        k8_client.sanitize_for_serialization(oauth_sidecar)
+    )
+    # add volume to headnode
+    # add sidecar container to ray object
+
+
+def _create_oauth_sidecar_object(
+    namespace: str,
+    tls_mount_location: str,
+    oauth_port: int,
+    oauth_sa_name: str,
+    tls_volume_name: str,
+    port_name: str,
+) -> client.V1Container:
+    return client.V1Container(
+        args=[
+            f"--https-address=:{oauth_port}",
+            "--provider=openshift",
+            f"--openshift-service-account={oauth_sa_name}",
+            "--upstream=http://localhost:8265",
+            f"--tls-cert={tls_mount_location}/tls.crt",
+            f"--tls-key={tls_mount_location}/tls.key",
+            f"--cookie-secret={b64encode(urandom(64)).decode('utf-8')}",  # create random string for encrypting cookie
+            f'--openshift-delegate-urls={{"/":{{"resource":"pods","namespace":"{namespace}","verb":"get"}}}}',
+        ],
+        image="registry.redhat.io/openshift4/ose-oauth-proxy@sha256:1ea6a01bf3e63cdcf125c6064cbd4a4a270deaf0f157b3eabb78f60556840366",
+        name="oauth-proxy",
+        ports=[client.V1ContainerPort(container_port=oauth_port, name=port_name)],
+        resources=client.V1ResourceRequirements(limits=None, requests=None),
+        volume_mounts=[
+            client.V1VolumeMount(
+                mount_path=tls_mount_location, name=tls_volume_name, read_only=True
+            )
+        ],
+    )
+
+
 def generate_appwrapper(
     name: str,
     namespace: str,
@@ -390,6 +476,7 @@ def generate_appwrapper(
     image_pull_secrets: list,
     dispatch_priority: str,
     priority_val: int,
+    openshift_oauth: bool,
 ):
     user_yaml = read_template(template)
     appwrapper_name, cluster_name = gen_names(name)
@@ -433,6 +520,10 @@ def generate_appwrapper(
         enable_local_interactive(resources, cluster_name, namespace)
     else:
         disable_raycluster_tls(resources["resources"])
+
+    if openshift_oauth:
+        enable_openshift_oauth(user_yaml, cluster_name, namespace)
+
     outfile = appwrapper_name + ".yaml"
     write_user_appwrapper(user_yaml, outfile)
     return outfile

--- a/src/codeflare_sdk/utils/kube_api_helpers.py
+++ b/src/codeflare_sdk/utils/kube_api_helpers.py
@@ -19,6 +19,7 @@ API error handling or wrapping.
 
 import executing
 from kubernetes import client, config
+from urllib3.util import parse_url
 
 
 # private methods
@@ -42,3 +43,7 @@ def _kube_api_error_handling(e: Exception):  # pragma: no cover
         elif e.reason == "Conflict":
             raise FileExistsError(exists_msg)
     raise e
+
+
+def _get_api_host(api_client: client.ApiClient):  # pragma: no cover
+    return parse_url(api_client.configuration.host).host

--- a/src/codeflare_sdk/utils/openshift_oauth.py
+++ b/src/codeflare_sdk/utils/openshift_oauth.py
@@ -1,0 +1,229 @@
+from urllib3.util import parse_url
+from .generate_yaml import gen_dashboard_route_name
+from base64 import b64decode
+
+from ..cluster.auth import config_check, api_config_handler
+
+from kubernetes import client
+
+
+def create_openshift_oauth_objects(cluster_name, namespace):
+    config_check()
+    api_client = api_config_handler()
+    oauth_port = 8443
+    oauth_sa_name = f"{cluster_name}-oauth-proxy"
+    tls_secret_name = _gen_tls_secret_name(cluster_name)
+    service_name = f"{cluster_name}-oauth"
+    port_name = "oauth-proxy"
+    host = parse_url(api_client.configuration.host).host
+
+    # replace "^api" with the expected host
+    host = f"{gen_dashboard_route_name(cluster_name)}-{namespace}.apps" + host.lstrip(
+        "api"
+    )
+
+    _create_or_replace_oauth_sa(namespace, oauth_sa_name, host)
+    _create_or_replace_oauth_service_obj(
+        cluster_name, namespace, oauth_port, tls_secret_name, service_name, port_name
+    )
+    _create_or_replace_oauth_ingress_object(
+        cluster_name, namespace, service_name, port_name, host
+    )
+    _create_or_replace_oauth_rb(cluster_name, namespace, oauth_sa_name)
+
+
+def _create_or_replace_oauth_sa(namespace, oauth_sa_name, host):
+    api_client = api_config_handler()
+    oauth_sa = client.V1ServiceAccount(
+        api_version="v1",
+        kind="ServiceAccount",
+        metadata=client.V1ObjectMeta(
+            name=oauth_sa_name,
+            namespace=namespace,
+            annotations={
+                "serviceaccounts.openshift.io/oauth-redirecturi.first": f"https://{host}"
+            },
+        ),
+    )
+    try:
+        client.CoreV1Api(api_client).create_namespaced_service_account(
+            namespace=namespace, body=oauth_sa
+        )
+    except client.ApiException as e:
+        if e.reason == "Conflict":
+            client.CoreV1Api(api_client).replace_namespaced_service_account(
+                namespace=namespace,
+                body=oauth_sa,
+                name=oauth_sa_name,
+            )
+        else:
+            raise e
+
+
+def _create_or_replace_oauth_rb(cluster_name, namespace, oauth_sa_name):
+    api_client = api_config_handler()
+    oauth_crb = client.V1ClusterRoleBinding(
+        api_version="rbac.authorization.k8s.io/v1",
+        kind="ClusterRoleBinding",
+        metadata=client.V1ObjectMeta(name=f"{cluster_name}-rb"),
+        role_ref=client.V1RoleRef(
+            api_group="rbac.authorization.k8s.io",
+            kind="ClusterRole",
+            name="system:auth-delegator",
+        ),
+        subjects=[
+            client.V1Subject(
+                kind="ServiceAccount", name=oauth_sa_name, namespace=namespace
+            )
+        ],
+    )
+    try:
+        client.RbacAuthorizationV1Api(api_client).create_cluster_role_binding(
+            body=oauth_crb
+        )
+    except client.ApiException as e:
+        if e.reason == "Conflict":
+            client.RbacAuthorizationV1Api(api_client).replace_cluster_role_binding(
+                body=oauth_crb, name=f"{cluster_name}-rb"
+            )
+        else:
+            raise e
+
+
+def _gen_tls_secret_name(cluster_name):
+    return f"{cluster_name}-proxy-tls-secret"
+
+
+def delete_openshift_oauth_objects(cluster_name, namespace):
+    # NOTE: it might be worth adding error handling here, but shouldn't be necessary because cluster.down(...) checks
+    # for an existing cluster before calling this => the objects should never be deleted twice
+    api_client = api_config_handler()
+    oauth_sa_name = f"{cluster_name}-oauth-proxy"
+    service_name = f"{cluster_name}-oauth"
+    client.CoreV1Api(api_client).delete_namespaced_service_account(
+        name=oauth_sa_name, namespace=namespace
+    )
+    client.CoreV1Api(api_client).delete_namespaced_service(
+        name=service_name, namespace=namespace
+    )
+    client.NetworkingV1Api(api_client).delete_namespaced_ingress(
+        name=f"{cluster_name}-ingress", namespace=namespace
+    )
+    client.RbacAuthorizationV1Api(api_client).delete_cluster_role_binding(
+        name=f"{cluster_name}-rb"
+    )
+
+
+def download_tls_cert(cluster_name, namespace, output_file):
+    api_client = api_config_handler()
+    b64_tls_cert = (
+        client.CoreV1Api(api_client)
+        .read_namespaced_secret(
+            name=_gen_tls_secret_name(cluster_name=cluster_name), namespace=namespace
+        )
+        .data["tls.crt"]
+    )
+    with open(output_file, "w+") as f:
+        f.write(b64decode(b64_tls_cert).decode("ascii"))
+
+
+def _create_or_replace_oauth_service_obj(
+    cluster_name: str,
+    namespace: str,
+    oauth_port: int,
+    tls_secret_name: str,
+    service_name: str,
+    port_name: str,
+) -> client.V1Service:
+    api_client = api_config_handler()
+    oauth_service = client.V1Service(
+        api_version="v1",
+        kind="Service",
+        metadata=client.V1ObjectMeta(
+            annotations={
+                "service.beta.openshift.io/serving-cert-secret-name": tls_secret_name
+            },
+            name=service_name,
+            namespace=namespace,
+        ),
+        spec=client.V1ServiceSpec(
+            ports=[
+                client.V1ServicePort(
+                    name=port_name,
+                    protocol="TCP",
+                    port=443,
+                    target_port=oauth_port,
+                )
+            ],
+            selector={
+                "app.kubernetes.io/created-by": "kuberay-operator",
+                "app.kubernetes.io/name": "kuberay",
+                "ray.io/cluster": cluster_name,
+                "ray.io/identifier": f"{cluster_name}-head",
+                "ray.io/node-type": "head",
+            },
+        ),
+    )
+    try:
+        client.CoreV1Api(api_client).create_namespaced_service(
+            namespace=namespace, body=oauth_service
+        )
+    except client.ApiException as e:
+        if e.reason == "Conflict":
+            client.CoreV1Api(api_client).replace_namespaced_service(
+                namespace=namespace, body=oauth_service, name=service_name
+            )
+        else:
+            raise e
+
+
+def _create_or_replace_oauth_ingress_object(
+    cluster_name: str,
+    namespace: str,
+    service_name: str,
+    port_name: str,
+    host: str,
+) -> client.V1Ingress:
+    api_client = api_config_handler()
+    ingress = client.V1Ingress(
+        api_version="networking.k8s.io/v1",
+        kind="Ingress",
+        metadata=client.V1ObjectMeta(
+            annotations={"route.openshift.io/termination": "passthrough"},
+            name=f"{cluster_name}-ingress",
+            namespace=namespace,
+        ),
+        spec=client.V1IngressSpec(
+            rules=[
+                client.V1IngressRule(
+                    host=host,
+                    http=client.V1HTTPIngressRuleValue(
+                        paths=[
+                            client.V1HTTPIngressPath(
+                                backend=client.V1IngressBackend(
+                                    service=client.V1IngressServiceBackend(
+                                        name=service_name,
+                                        port=client.V1ServiceBackendPort(
+                                            name=port_name
+                                        ),
+                                    )
+                                ),
+                                path_type="ImplementationSpecific",
+                            )
+                        ]
+                    ),
+                )
+            ]
+        ),
+    )
+    try:
+        client.NetworkingV1Api(api_client).create_namespaced_ingress(
+            namespace=namespace, body=ingress
+        )
+    except client.ApiException as e:
+        if e.reason == "Conflict":
+            client.NetworkingV1Api(api_client).replace_namespaced_ingress(
+                namespace=namespace, body=ingress, name=f"{cluster_name}-ingress"
+            )
+        else:
+            raise e

--- a/src/codeflare_sdk/utils/openshift_oauth.py
+++ b/src/codeflare_sdk/utils/openshift_oauth.py
@@ -7,6 +7,10 @@ from ..cluster.auth import config_check, api_config_handler
 from kubernetes import client
 
 
+def _get_api_host(api_client: client.ApiClient):
+    return parse_url(api_client.configuration.host).host
+
+
 def create_openshift_oauth_objects(cluster_name, namespace):
     config_check()
     api_client = api_config_handler()
@@ -15,7 +19,7 @@ def create_openshift_oauth_objects(cluster_name, namespace):
     tls_secret_name = _gen_tls_secret_name(cluster_name)
     service_name = f"{cluster_name}-oauth"
     port_name = "oauth-proxy"
-    host = parse_url(api_client.configuration.host).host
+    host = _get_api_host(api_client)
 
     # replace "^api" with the expected host
     host = f"{gen_dashboard_route_name(cluster_name)}-{namespace}.apps" + host.lstrip(

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO: replace all instances of torchx_runner
+
 from pathlib import Path
 import sys
 import filecmp
@@ -58,7 +60,6 @@ from codeflare_sdk.job.jobs import (
     Job,
     DDPJobDefinition,
     DDPJob,
-    torchx_runner,
 )
 from codeflare_sdk.utils.generate_cert import (
     generate_ca_cert,
@@ -83,7 +84,9 @@ from torchx.schedulers.ray_scheduler import RayJob
 from torchx.schedulers.kubernetes_mcad_scheduler import KubernetesMCADJob
 import pytest
 import yaml
-
+from unittest.mock import MagicMock
+from pytest_mock import MockerFixture
+from ray.job_submission import JobSubmissionClient
 
 # For mocking openshift client results
 fake_res = openshift.Result("fake")
@@ -1835,7 +1838,7 @@ def test_DDPJobDefinition_creation():
     assert ddp.scheduler_args == {"requirements": "test"}
 
 
-def test_DDPJobDefinition_dry_run(mocker):
+def test_DDPJobDefinition_dry_run(mocker: MockerFixture):
     """
     Test that the dry run method returns the correct type: AppDryRunInfo,
     that the attributes of the returned object are of the correct type,
@@ -1846,9 +1849,10 @@ def test_DDPJobDefinition_dry_run(mocker):
         "codeflare_sdk.cluster.cluster.Cluster.cluster_dashboard_uri",
         return_value="",
     )
+    mocker.patch.object(Cluster, "client")
     ddp = createTestDDP()
     cluster = createClusterWithConfig()
-    ddp_job = ddp._dry_run(cluster)
+    ddp_job, _ = ddp._dry_run(cluster)
     assert type(ddp_job) == AppDryRunInfo
     assert ddp_job._fmt is not None
     assert type(ddp_job.request) == RayJob
@@ -1884,7 +1888,7 @@ def test_DDPJobDefinition_dry_run_no_cluster(mocker):
 
     ddp = createTestDDP()
     ddp.image = "fake-image"
-    ddp_job = ddp._dry_run_no_cluster()
+    ddp_job, _ = ddp._dry_run_no_cluster()
     assert type(ddp_job) == AppDryRunInfo
     assert ddp_job._fmt is not None
     assert type(ddp_job.request) == KubernetesMCADJob
@@ -1915,6 +1919,7 @@ def test_DDPJobDefinition_dry_run_no_resource_args(mocker):
     Test that the dry run correctly gets resources from the cluster object
     when the job definition does not specify resources.
     """
+    mocker.patch.object(Cluster, "client")
     mocker.patch(
         "codeflare_sdk.cluster.cluster.Cluster.cluster_dashboard_uri",
         return_value="",
@@ -1932,7 +1937,7 @@ def test_DDPJobDefinition_dry_run_no_resource_args(mocker):
         rdzv_port=29500,
         scheduler_args={"requirements": "test"},
     )
-    ddp_job = ddp._dry_run(cluster)
+    ddp_job, _ = ddp._dry_run(cluster)
 
     assert ddp_job._app.roles[0].resource.cpu == cluster.config.max_cpus
     assert ddp_job._app.roles[0].resource.gpu == cluster.config.num_gpus
@@ -1998,25 +2003,24 @@ def test_DDPJobDefinition_dry_run_no_cluster_no_resource_args(mocker):
         assert str(e) == "Job definition missing arg: j (`workers`x`procs`)"
 
 
-def test_DDPJobDefinition_submit(mocker):
+def test_DDPJobDefinition_submit(mocker: MockerFixture):
     """
     Tests that the submit method returns the correct type: DDPJob
     And that the attributes of the returned object are of the correct type
     """
-    mocker.patch(
-        "codeflare_sdk.cluster.cluster.Cluster.cluster_dashboard_uri",
-        return_value="fake-dashboard-uri",
-    )
+    mock_schedule = MagicMock()
+    mocker.patch.object(Runner, "schedule", mock_schedule)
+    mock_schedule.return_value = "fake-dashboard-url"
+    mocker.patch.object(Cluster, "client")
     ddp_def = createTestDDP()
     cluster = createClusterWithConfig()
     mocker.patch(
         "codeflare_sdk.job.jobs.get_current_namespace",
         side_effect="opendatahub",
     )
-    mocker.patch(
-        "codeflare_sdk.job.jobs.torchx_runner.schedule",
-        return_value="fake-dashboard-url",
-    )  # a fake app_handle
+    mocker.patch.object(
+        Cluster, "cluster_dashboard_uri", return_value="fake-dashboard-url"
+    )
     ddp_job = ddp_def.submit(cluster)
     assert type(ddp_job) == DDPJob
     assert type(ddp_job.job_definition) == DDPJobDefinition
@@ -2033,24 +2037,23 @@ def test_DDPJobDefinition_submit(mocker):
     assert ddp_job._app_handle == "fake-dashboard-url"
 
 
-def test_DDPJob_creation(mocker):
-    mocker.patch(
-        "codeflare_sdk.cluster.cluster.Cluster.cluster_dashboard_uri",
-        return_value="fake-dashboard-uri",
+def test_DDPJob_creation(mocker: MockerFixture):
+    mocker.patch.object(Cluster, "client")
+    mock_schedule = MagicMock()
+    mocker.patch.object(Runner, "schedule", mock_schedule)
+    mocker.patch.object(
+        Cluster, "cluster_dashboard_uri", return_value="fake-dashboard-url"
     )
     ddp_def = createTestDDP()
     cluster = createClusterWithConfig()
-    mocker.patch(
-        "codeflare_sdk.job.jobs.torchx_runner.schedule",
-        return_value="fake-dashboard-url",
-    )  # a fake app_handle
+    mock_schedule.return_value = "fake-dashboard-url"
     ddp_job = createDDPJob_with_cluster(ddp_def, cluster)
     assert type(ddp_job) == DDPJob
     assert type(ddp_job.job_definition) == DDPJobDefinition
     assert type(ddp_job.cluster) == Cluster
     assert type(ddp_job._app_handle) == str
     assert ddp_job._app_handle == "fake-dashboard-url"
-    _, args, kwargs = torchx_runner.schedule.mock_calls[0]
+    _, args, kwargs = mock_schedule.mock_calls[0]
     assert type(args[0]) == AppDryRunInfo
     job_info = args[0]
     assert type(job_info.request) == RayJob
@@ -2059,24 +2062,23 @@ def test_DDPJob_creation(mocker):
     assert type(job_info._scheduler) == type(str())
 
 
-def test_DDPJob_creation_no_cluster(mocker):
+def test_DDPJob_creation_no_cluster(mocker: MockerFixture):
     ddp_def = createTestDDP()
     ddp_def.image = "fake-image"
     mocker.patch(
         "codeflare_sdk.job.jobs.get_current_namespace",
         side_effect="opendatahub",
     )
-    mocker.patch(
-        "codeflare_sdk.job.jobs.torchx_runner.schedule",
-        return_value="fake-app-handle",
-    )  # a fake app_handle
+    mock_schedule = MagicMock()
+    mocker.patch.object(Runner, "schedule", mock_schedule)
+    mock_schedule.return_value = "fake-app-handle"
     ddp_job = createDDPJob_no_cluster(ddp_def, None)
     assert type(ddp_job) == DDPJob
     assert type(ddp_job.job_definition) == DDPJobDefinition
     assert ddp_job.cluster == None
     assert type(ddp_job._app_handle) == str
     assert ddp_job._app_handle == "fake-app-handle"
-    _, args, kwargs = torchx_runner.schedule.mock_calls[0]
+    _, args, kwargs = mock_schedule.mock_calls[0]
     assert type(args[0]) == AppDryRunInfo
     job_info = args[0]
     assert type(job_info.request) == KubernetesMCADJob
@@ -2085,31 +2087,31 @@ def test_DDPJob_creation_no_cluster(mocker):
     assert type(job_info._scheduler) == type(str())
 
 
-def test_DDPJob_status(mocker):
+def test_DDPJob_status(mocker: MockerFixture):
     # Setup the neccesary mock patches
+    mock_status = MagicMock()
+    mocker.patch.object(Runner, "status", mock_status)
     test_DDPJob_creation(mocker)
     ddp_def = createTestDDP()
     cluster = createClusterWithConfig()
     ddp_job = createDDPJob_with_cluster(ddp_def, cluster)
-    mocker.patch(
-        "codeflare_sdk.job.jobs.torchx_runner.status", return_value="fake-status"
-    )
+    mock_status.return_value = "fake-status"
     assert ddp_job.status() == "fake-status"
-    _, args, kwargs = torchx_runner.status.mock_calls[0]
+    _, args, kwargs = mock_status.mock_calls[0]
     assert args[0] == "fake-dashboard-url"
 
 
-def test_DDPJob_logs(mocker):
+def test_DDPJob_logs(mocker: MockerFixture):
+    mock_log = MagicMock()
+    mocker.patch.object(Runner, "log_lines", mock_log)
     # Setup the neccesary mock patches
     test_DDPJob_creation(mocker)
     ddp_def = createTestDDP()
     cluster = createClusterWithConfig()
     ddp_job = createDDPJob_with_cluster(ddp_def, cluster)
-    mocker.patch(
-        "codeflare_sdk.job.jobs.torchx_runner.log_lines", return_value="fake-logs"
-    )
+    mock_log.return_value = "fake-logs"
     assert ddp_job.logs() == "fake-logs"
-    _, args, kwargs = torchx_runner.log_lines.mock_calls[0]
+    _, args, kwargs = mock_log.mock_calls[0]
     assert args[0] == "fake-dashboard-url"
 
 
@@ -2117,7 +2119,9 @@ def arg_check_side_effect(*args):
     assert args[0] == "fake-app-handle"
 
 
-def test_DDPJob_cancel(mocker):
+def test_DDPJob_cancel(mocker: MockerFixture):
+    mock_cancel = MagicMock()
+    mocker.patch.object(Runner, "cancel", mock_cancel)
     # Setup the neccesary mock patches
     test_DDPJob_creation_no_cluster(mocker)
     ddp_def = createTestDDP()
@@ -2127,9 +2131,7 @@ def test_DDPJob_cancel(mocker):
         "openshift.get_project_name",
         return_value="opendatahub",
     )
-    mocker.patch(
-        "codeflare_sdk.job.jobs.torchx_runner.cancel", side_effect=arg_check_side_effect
-    )
+    mock_cancel.side_effect = arg_check_side_effect
     ddp_job.cancel()
 
 


### PR DESCRIPTION
# Issue link
closes: #174 

# What changes have been made
I added functions which create the necessary objects and update the appwrapper so that the SDK can create a ray cluster with an OAuth Proxy in front of the dashboard.

- OAuth sidecar container and tls secret mount
- Ingress with annotations for tls passthrough
- Service which points to OAuth port in the sidecar container and annotations for autogenerated tls certs
- Service account which contains the OAuth Callback
- ClusterRoleBinding giving OAuth sidecar necessary permissions

# Verification steps
go through notebook but set `openshift_oauth` to true in the config

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
