### PR TITLE
Updated ray version in base template to 2.5.0

### DIFF
--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -49,7 +49,7 @@ spec:
           # - kubernetes
         spec:
           # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-          rayVersion: '2.1.0'
+          rayVersion: '2.5.0'
           # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
           # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
           # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -109,7 +109,7 @@ spec:
                       nvidia.com/gpu: 0
                 imagePullSecrets:
                 - name: unit-test-pull-secret
-          rayVersion: 2.1.0
+          rayVersion: 2.5.0
           workerGroupSpecs:
           - groupName: small-group-unit-test-cluster
             maxReplicas: 2


### PR DESCRIPTION
# Issue link
#299 

# What changes have been made
Updated rayVersion field in AppWrapper yaml to 2.5.0

# Verification steps
Generate appwrapper via Cluster()
Check `rayVersion` field
Verify it is 2.5.0

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
