### PR TITLE
Fix Dashboard URI returned by cluster.status()

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -310,7 +310,8 @@ class Cluster:
 
         for route in routes["items"]:
             if route["metadata"]["name"] == f"ray-dashboard-{self.config.name}":
-                return f"http://{route['spec']['host']}"
+                protocol = "https" if route["spec"].get("tls") else "http"
+                return f"{protocol}://{route['spec']['host']}"
         return "Dashboard route not available yet, have you run cluster.up()?"
 
     def list_jobs(self) -> List:
@@ -585,7 +586,8 @@ def _map_to_ray_cluster(rc) -> Optional[RayCluster]:
     ray_route = None
     for route in routes["items"]:
         if route["metadata"]["name"] == f"ray-dashboard-{rc['metadata']['name']}":
-            ray_route = route["spec"]["host"]
+            protocol = "https" if route["spec"].get("tls") else "http"
+            ray_route = f"{protocol}://{route['spec']['host']}"
 
     return RayCluster(
         name=rc["metadata"]["name"],


### PR DESCRIPTION
# Issue link
Closes #316 


# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
This change fixes the issue where the hyperlink provided by the cluster.status() method is incorrect.

Previously the hyperlink provided resolved to a relative path as opposed to the absolute Ray Dashboard URI. For this reason, I prefixed `http://` to ensure the hyperlink points to the correct URI.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
1. In a cluster go to the Open Datahub dashboard and create a Jupyter Notebook
2. Uninstall the current codeflare-sdk with pip uninstall codeflare-sdk -y
3. Install the codeflare-sdk from this branch: You will need to run `poetry build` to generate a wheel of the SDK.
4. Upload the wheel to the Jupyter Notebook, and install the build with `pip install codeflare_sdk-0.0.0.dev0-py3-none-any.whl`.
5. Restart the Notebook Kernel
6. Run through one of the guided-demos i.e.: 0_basic_ray.ipynb
7. When running through the demo, after running cluster.status() you can attempt to open the Ray Dashboard through the provided hyperlink.

## Checks

- Testing Strategy
   - [x] Manual tests

