### PR TITLE
Add is_dashboard_ready function + update unit test

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1753,6 +1753,21 @@ def test_wait_ready(mocker, capsys):
     mocker.patch("kubernetes.config.load_kube_config", return_value="ignore")
     mocker.patch("codeflare_sdk.cluster.cluster._app_wrapper_status", return_value=None)
     mocker.patch("codeflare_sdk.cluster.cluster._ray_cluster_status", return_value=None)
+    mocker.patch.object(
+        client.CustomObjectsApi,
+        "list_namespaced_custom_object",
+        return_value={
+            "items": [
+                {
+                    "metadata": {"name": "ray-dashboard-test"},
+                    "spec": {"host": "mocked-host"},
+                }
+            ]
+        },
+    )
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mocker.patch("requests.get", return_value=mock_response)
     cf = Cluster(ClusterConfiguration(name="test", namespace="ns"))
     try:
         cf.wait_ready(timeout=5)
@@ -1773,7 +1788,7 @@ def test_wait_ready(mocker, capsys):
     captured = capsys.readouterr()
     assert (
         captured.out
-        == "Waiting for requested resources to be set up...\nRequested cluster up and running!\n"
+        == "Waiting for requested resources to be set up...\nRequested cluster and dashboard are up and running!\n"
     )
 
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes #314 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Added an `is_dashboard_ready` function that is used to check for the dashboard's availability. This is done by sending a request to the Dashboard URI, where if status code equals 200 we return `True`.
- This new function is called within the `wait_ready` function to ensure that both the cluster and the dashboard are operational.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
I updated the unit tests to reflect these changes on the `wait_ready` function. All tests are passing.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
