### PR TITLE
Disabled Insecure request warning after login

### DIFF
--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -109,11 +109,13 @@ class TokenAuthentication(Authentication):
             elif self.skip_tls == False:
                 configuration.ssl_ca_cert = self.ca_cert_path
             else:
+                urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+                print("Insecure request warnings have been disabled")
                 configuration.verify_ssl = False
+
             api_client = client.ApiClient(configuration)
             client.AuthenticationApi(api_client).get_api_group()
             config_path = None
-            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
             return "Logged into %s" % self.server
         except client.ApiException:  # pragma: no cover
             api_client = None

--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -22,6 +22,7 @@ authenticate to their cluster or add their own custom concrete classes here.
 import abc
 from kubernetes import client, config
 import os
+import urllib3
 from ..utils.kube_api_helpers import _kube_api_error_handling
 
 global api_client
@@ -112,6 +113,7 @@ class TokenAuthentication(Authentication):
             api_client = client.ApiClient(configuration)
             client.AuthenticationApi(api_client).get_api_group()
             config_path = None
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
             return "Logged into %s" % self.server
         except client.ApiException:  # pragma: no cover
             api_client = None


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes #319 
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Disabled Insecure request warning after login when setting `skip_tls=True`
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Following a guided demo
Login with `skip_tls=True`
You should get a warning message similar to...
```
warnings.warn(
/opt/app-root/lib64/python3.8/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host <HOST>. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
```
Follow the rest of the guided demo and you shouldn't see the warning again.
## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
