### PR TITLE
Refactor unit tests to eliminate pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,9 @@ pdoc3 = "0.10.0"
 pytest = "7.4.0"
 coverage = "7.2.7"
 pytest-mock = "3.11.1"
+
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore::DeprecationWarning:pkg_resources",
+    "ignore:pkg_resources is deprecated as an API:DeprecationWarning",
+]

--- a/tests/unit_test_support.py
+++ b/tests/unit_test_support.py
@@ -1,0 +1,60 @@
+from codeflare_sdk.job.jobs import (
+    DDPJobDefinition,
+    DDPJob,
+)
+
+from codeflare_sdk.cluster.cluster import (
+    Cluster,
+    ClusterConfiguration,
+)
+
+
+def createTestDDP():
+    ddp = DDPJobDefinition(
+        script="test.py",
+        m=None,
+        script_args=["test"],
+        name="test",
+        cpu=1,
+        gpu=0,
+        memMB=1024,
+        h=None,
+        j="2x1",
+        env={"test": "test"},
+        max_retries=0,
+        mounts=[],
+        rdzv_port=29500,
+        scheduler_args={"requirements": "test"},
+    )
+    return ddp
+
+
+def createDDPJob_no_cluster(ddp_def, cluster):
+    return DDPJob(ddp_def, cluster)
+
+
+def createClusterConfig():
+    config = ClusterConfiguration(
+        name="unit-test-cluster",
+        namespace="ns",
+        num_workers=2,
+        min_cpus=3,
+        max_cpus=4,
+        min_memory=5,
+        max_memory=6,
+        num_gpus=7,
+        instascale=True,
+        machine_types=["cpu.small", "gpu.large"],
+        image_pull_secrets=["unit-test-pull-secret"],
+        dispatch_priority="default",
+    )
+    return config
+
+
+def createClusterWithConfig():
+    cluster = Cluster(createClusterConfig())
+    return cluster
+
+
+def createDDPJob_with_cluster(ddp_def, cluster=createClusterWithConfig()):
+    return DDPJob(ddp_def, cluster)


### PR DESCRIPTION

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes #321 

# Cause of Warnings
- 7 of the warnings arise from tests that include a return statement. It seems these should only be making assertions and not returning anything. This way, pytest won't display any warnings.

- The 4 other warnings are related to pkg_resources deprecation. I am unsure where this is coming from (it's not in the repo), it seems like an indirect library call:
![image](https://github.com/project-codeflare/codeflare-sdk/assets/73656840/df4268ea-7296-4b2c-839b-80bf5e9766c6)
Based on this [GitHub issue on google-cloud-python](https://github.com/googleapis/google-cloud-python/issues/11184) and this [PR on ibis repo](https://github.com/ibis-project/ibis/pull/5980), it seems people are inclined to silence these warnings for the meantime.


# Changes
- Refactored to remove return statements from the tests that are run.
- Created the respective support functions.
- Silenced warnings that originate from pkg_resources.


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
1. From this branch, run in the terminal `pip install -e .`
2. Then run: `pytest -v tests/unit_test.py`
3. All tests should be passing without any warnings as shown below.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
![image](https://github.com/project-codeflare/codeflare-sdk/assets/73656840/edb3ac21-8a99-4fd1-897a-3c049be97f32)

