### PR TITLE
[WIP] set head node ip in jobs

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -313,6 +313,22 @@ class Cluster:
                 return f"http://{route['spec']['host']}"
         return "Dashboard route not available yet, have you run cluster.up()?"
 
+    def get_head_ip(self) -> str:
+        """
+        Returns a string containing the cluster's head node IP.
+        """
+        try:
+            config_check()
+            api_instance = client.CoreV1Api()
+            ret = api_instance.list_namespaced_pod_with_http_info(
+                self.config.namespace
+            )[0]
+            for pod in ret.items:
+                if f"{self.config.name}-head-" in pod.metadata.name:
+                    return pod.status.pod_ip
+        except Exception as e:  # pragma: no cover
+            return _kube_api_error_handling(e)
+
     def list_jobs(self) -> List:
         """
         This method accesses the head ray node in your cluster and lists the running jobs.


### PR DESCRIPTION
# Issue link
https://github.com/project-codeflare/torchx/issues/4 

# What changes have been made
In working through the upstreaming of our changes, I discovered that we could move some of the logic into the SDK itself. This is better for our use case as we have specific needs and the ability to control job submissions that the average torchx users  likely does not have. 

 I've added a new function in `Cluster`, `get_head_ip` that returns the ip address of the head ray node within the cluster. 

I've added a new function to `DDPJobDefinition`, `_set_rdzv_as_head_node` that updates the torchx cmd arguments to force the use of the head node as the rdzv endpoint. 

I also rearranged how `_dry_run` calls ddp to allow editing of its outputs prior to a job submission. 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
