### PR TITLE
remove scheduling spec

### DIFF
--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -8,8 +8,6 @@ metadata:
     orderedinstance: "m4.xlarge_g4dn.xlarge"
 spec:
   priority: 9
-  schedulingSpec:
-    minAvailable: 3
   resources:
     Items: []
     GenericItems:

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -89,7 +89,7 @@ def update_labels(yaml, instascale, instance_types):
         metadata.pop("labels")
 
 
-def update_priority(yaml, item, workers, dispatch_priority):
+def update_priority(item, dispatch_priority):
     if dispatch_priority is not None:
         head = item.get("generictemplate").get("spec").get("headGroupSpec")
         worker = item.get("generictemplate").get("spec").get("workerGroupSpecs")[0]
@@ -363,7 +363,7 @@ def generate_appwrapper(
     route_item = resources["resources"].get("GenericItems")[1]
     update_names(user_yaml, item, appwrapper_name, cluster_name, namespace)
     update_labels(user_yaml, instascale, instance_types)
-    update_priority(user_yaml, item, workers, dispatch_priority)
+    update_priority(item, dispatch_priority)
     update_custompodresources(
         item, min_cpu, max_cpu, min_memory, max_memory, gpu, workers
     )

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -95,13 +95,6 @@ def update_priority(yaml, item, workers, dispatch_priority):
         worker = item.get("generictemplate").get("spec").get("workerGroupSpecs")[0]
         head["template"]["spec"]["priorityClassName"] = dispatch_priority
         worker["template"]["spec"]["priorityClassName"] = dispatch_priority
-        update_scheduling_spec(yaml, workers)
-
-
-def update_scheduling_spec(yaml, workers):
-    spec = yaml.get("spec")
-    spec["schedulingSpec"] = {"minAvailable": ""}
-    spec["schedulingSpec"]["minAvailable"] = workers + 1
 
 
 def update_custompodresources(

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -195,5 +195,3 @@ spec:
             name: unit-test-cluster-head-svc
       replicas: 1
     Items: []
-  schedulingSpec:
-    minAvailable: 3


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Found bug where "schedulingSpec" is added to the appwrapper without the use of a propriety class. This can cause the Ray Clusters to get stuck in a creation/deletion loop. 

Updated the base template and changed how the schedulingSpec get created to ensure its only added to the appwrapper along with priorityClasses. 


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
