### PR TITLE
RayCluster status safeguards

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -562,7 +562,7 @@ def _get_app_wrappers(
 
 
 def _map_to_ray_cluster(rc) -> Optional[RayCluster]:
-    if "state" in rc["status"]:
+    if "status" in rc and "state" in rc["status"]:
         status = RayClusterStatus(rc["status"]["state"].lower())
     else:
         status = RayClusterStatus.UNKNOWN


### PR DESCRIPTION
# Issue link
closes #339 

# What changes have been made
Added error handling to prevent cluster.status/wait_ready crashes due to missing RayCluster status
This PR is an extension of #254 

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
