### PR TITLE
Updated AW API Group to codeflare.dev

### DIFF
--- a/demo-notebooks/guided-demos/notebook-ex-outputs/gptfttest.yaml
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/gptfttest.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   labels:
@@ -33,7 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: gptfttest
+            appwrapper.codeflare.dev: gptfttest
             controller-tools.k8s.io: '1.0'
           name: gptfttest
           namespace: default

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/instascaletest.yaml
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/instascaletest.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   labels:
@@ -33,7 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: instascaletest
+            appwrapper.codeflare.dev: instascaletest
             controller-tools.k8s.io: '1.0'
           name: instascaletest
           namespace: default

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/interactivetest.yaml
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/interactivetest.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   labels:
@@ -33,7 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: interactivetest
+            appwrapper.codeflare.dev: interactivetest
             controller-tools.k8s.io: '1.0'
           name: interactivetest
           namespace: default

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/jobtest.yaml
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/jobtest.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   name: jobtest
@@ -31,7 +31,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: jobtest
+            appwrapper.codeflare.dev: jobtest
             controller-tools.k8s.io: '1.0'
           name: jobtest
           namespace: default

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/raytest.yaml
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/raytest.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   name: raytest
@@ -31,7 +31,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: raytest
+            appwrapper.codeflare.dev: raytest
             controller-tools.k8s.io: '1.0'
           name: raytest
           namespace: default

--- a/src/codeflare_sdk/cluster/awload.py
+++ b/src/codeflare_sdk/cluster/awload.py
@@ -61,7 +61,7 @@ class AWManager:
             config_check()
             api_instance = client.CustomObjectsApi(api_config_handler())
             api_instance.create_namespaced_custom_object(
-                group="mcad.ibm.com",
+                group="codeflare.dev",
                 version="v1beta1",
                 namespace=self.namespace,
                 plural="appwrappers",
@@ -86,7 +86,7 @@ class AWManager:
             config_check()
             api_instance = client.CustomObjectsApi(api_config_handler())
             api_instance.delete_namespaced_custom_object(
-                group="mcad.ibm.com",
+                group="codeflare.dev",
                 version="v1beta1",
                 namespace=self.namespace,
                 plural="appwrappers",

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -156,7 +156,7 @@ class Cluster:
             with open(self.app_wrapper_yaml) as f:
                 aw = yaml.load(f, Loader=yaml.FullLoader)
             api_instance.create_namespaced_custom_object(
-                group="mcad.ibm.com",
+                group="codeflare.dev",
                 version="v1beta1",
                 namespace=namespace,
                 plural="appwrappers",
@@ -175,7 +175,7 @@ class Cluster:
             config_check()
             api_instance = client.CustomObjectsApi(api_config_handler())
             api_instance.delete_namespaced_custom_object(
-                group="mcad.ibm.com",
+                group="codeflare.dev",
                 version="v1beta1",
                 namespace=namespace,
                 plural="appwrappers",
@@ -492,7 +492,7 @@ def _app_wrapper_status(name, namespace="default") -> Optional[AppWrapper]:
         config_check()
         api_instance = client.CustomObjectsApi(api_config_handler())
         aws = api_instance.list_namespaced_custom_object(
-            group="mcad.ibm.com",
+            group="codeflare.dev",
             version="v1beta1",
             namespace=namespace,
             plural="appwrappers",
@@ -553,7 +553,7 @@ def _get_app_wrappers(
         config_check()
         api_instance = client.CustomObjectsApi(api_config_handler())
         aws = api_instance.list_namespaced_custom_object(
-            group="mcad.ibm.com",
+            group="codeflare.dev",
             version="v1beta1",
             namespace=namespace,
             plural="appwrappers",

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   name: aw-kuberay
@@ -41,7 +41,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: "aw-kuberay"
+            appwrapper.codeflare.dev: "aw-kuberay"
             controller-tools.k8s.io: "1.0"
             # A unique identifier for the head node and workers of this cluster.
           name: kuberay-cluster

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -68,7 +68,7 @@ def update_names(yaml, item, appwrapper_name, cluster_name, namespace):
     metadata["name"] = appwrapper_name
     metadata["namespace"] = namespace
     lower_meta = item.get("generictemplate", {}).get("metadata")
-    lower_meta["labels"]["appwrapper.mcad.ibm.com"] = appwrapper_name
+    lower_meta["labels"]["appwrapper.codeflare.dev"] = appwrapper_name
     lower_meta["name"] = cluster_name
     lower_meta["namespace"] = namespace
 

--- a/tests/test-case-bad.yaml
+++ b/tests/test-case-bad.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppsWrapper
 metadata:
   labels:
@@ -33,7 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: unit-test-cluster
+            appwrapper.codeflare.dev: unit-test-cluster
             controller-tools.k8s.io: '1.0'
           name: unit-test-cluster
           namespace: ns

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   labels:
@@ -33,7 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: prio-test-cluster
+            appwrapper.codeflare.dev: prio-test-cluster
             controller-tools.k8s.io: '1.0'
           name: prio-test-cluster
           namespace: ns

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -1,4 +1,4 @@
-apiVersion: mcad.ibm.com/v1beta1
+apiVersion: codeflare.dev/v1beta1
 kind: AppWrapper
 metadata:
   labels:
@@ -32,7 +32,7 @@ spec:
         kind: RayCluster
         metadata:
           labels:
-            appwrapper.mcad.ibm.com: unit-test-cluster
+            appwrapper.codeflare.dev: unit-test-cluster
             controller-tools.k8s.io: '1.0'
           name: unit-test-cluster
           namespace: ns

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -281,7 +281,7 @@ def test_default_cluster_creation(mocker):
 
 
 def arg_check_apply_effect(group, version, namespace, plural, body, *args):
-    assert group == "mcad.ibm.com"
+    assert group == "codeflare.dev"
     assert version == "v1beta1"
     assert namespace == "ns"
     assert plural == "appwrappers"
@@ -292,7 +292,7 @@ def arg_check_apply_effect(group, version, namespace, plural, body, *args):
 
 
 def arg_check_del_effect(group, version, namespace, plural, name, *args):
-    assert group == "mcad.ibm.com"
+    assert group == "codeflare.dev"
     assert version == "v1beta1"
     assert namespace == "ns"
     assert plural == "appwrappers"
@@ -320,7 +320,7 @@ def test_cluster_up_down(mocker):
 
 
 def aw_status_fields(group, version, namespace, plural, *args):
-    assert group == "mcad.ibm.com"
+    assert group == "codeflare.dev"
     assert version == "v1beta1"
     assert namespace == "test-ns"
     assert plural == "appwrappers"
@@ -651,7 +651,7 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                     "creationTimestamp": "2023-02-22T16:26:07Z",
                     "generation": 1,
                     "labels": {
-                        "appwrapper.mcad.ibm.com": "quicktest",
+                        "appwrapper.codeflare.dev": "quicktest",
                         "controller-tools.k8s.io": "1.0",
                         "resourceName": "quicktest",
                         "orderedinstance": "m4.xlarge_g4dn.xlarge",
@@ -664,7 +664,7 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                                 "f:metadata": {
                                     "f:labels": {
                                         ".": {},
-                                        "f:appwrapper.mcad.ibm.com": {},
+                                        "f:appwrapper.codeflare.dev": {},
                                         "f:controller-tools.k8s.io": {},
                                         "f:resourceName": {},
                                     },
@@ -747,7 +747,7 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                     "namespace": "ns",
                     "ownerReferences": [
                         {
-                            "apiVersion": "mcad.ibm.com/v1beta1",
+                            "apiVersion": "codeflare.dev/v1beta1",
                             "blockOwnerDeletion": True,
                             "controller": True,
                             "kind": "AppWrapper",
@@ -920,17 +920,17 @@ def get_aw_obj(group, version, namespace, plural):
     api_obj1 = {
         "items": [
             {
-                "apiVersion": "mcad.ibm.com/v1beta1",
+                "apiVersion": "codeflare.dev/v1beta1",
                 "kind": "AppWrapper",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": '{"apiVersion":"mcad.ibm.com/v1beta1","kind":"AppWrapper","metadata":{"annotations":{},"name":"quicktest1","namespace":"ns"},"spec":{"priority":9,"resources":{"GenericItems":[{"custompodresources":[{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}},{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}],"generictemplate":{"apiVersion":"ray.io/v1alpha1","kind":"RayCluster","metadata":{"labels":{"appwrapper.mcad.ibm.com":"quicktest1","controller-tools.k8s.io":"1.0"},"name":"quicktest1","namespace":"ns"},"spec":{"autoscalerOptions":{"idleTimeoutSeconds":60,"imagePullPolicy":"Always","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"upscalingMode":"Default"},"enableInTreeAutoscaling":false,"headGroupSpec":{"rayStartParams":{"block":"true","dashboard-host":"0.0.0.0","num-gpus":"0"},"serviceType":"ClusterIP","template":{"spec":{"containers":[{"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","imagePullPolicy":"Always","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"ray-head","ports":[{"containerPort":6379,"name":"gcs"},{"containerPort":8265,"name":"dashboard"},{"containerPort":10001,"name":"client"}],"resources":{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}}}]}}},"rayVersion":"1.12.0","workerGroupSpecs":[{"groupName":"small-group-quicktest","maxReplicas":1,"minReplicas":1,"rayStartParams":{"block":"true","num-gpus":"0"},"replicas":1,"template":{"metadata":{"annotations":{"key":"value"},"labels":{"key":"value"}},"spec":{"containers":[{"env":[{"name":"MY_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}}],"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"machine-learning","resources":{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}}],"initContainers":[{"command":["sh","-c","until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"],"image":"busybox:1.28","name":"init-myservice"}]}}}]}},"replicas":1},{"generictemplate":{"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"labels":{"odh-ray-cluster-service":"quicktest-head-svc"},"name":"ray-dashboard-quicktest","namespace":"default"},"spec":{"port":{"targetPort":"dashboard"},"to":{"kind":"Service","name":"quicktest-head-svc"}}},"replica":1}],"Items":[]}}}\n'
+                        "kubectl.kubernetes.io/last-applied-configuration": '{"apiVersion":"codeflare.dev/v1beta1","kind":"AppWrapper","metadata":{"annotations":{},"name":"quicktest1","namespace":"ns"},"spec":{"priority":9,"resources":{"GenericItems":[{"custompodresources":[{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}},{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}],"generictemplate":{"apiVersion":"ray.io/v1alpha1","kind":"RayCluster","metadata":{"labels":{"appwrapper.codeflare.dev":"quicktest1","controller-tools.k8s.io":"1.0"},"name":"quicktest1","namespace":"ns"},"spec":{"autoscalerOptions":{"idleTimeoutSeconds":60,"imagePullPolicy":"Always","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"upscalingMode":"Default"},"enableInTreeAutoscaling":false,"headGroupSpec":{"rayStartParams":{"block":"true","dashboard-host":"0.0.0.0","num-gpus":"0"},"serviceType":"ClusterIP","template":{"spec":{"containers":[{"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","imagePullPolicy":"Always","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"ray-head","ports":[{"containerPort":6379,"name":"gcs"},{"containerPort":8265,"name":"dashboard"},{"containerPort":10001,"name":"client"}],"resources":{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}}}]}}},"rayVersion":"1.12.0","workerGroupSpecs":[{"groupName":"small-group-quicktest","maxReplicas":1,"minReplicas":1,"rayStartParams":{"block":"true","num-gpus":"0"},"replicas":1,"template":{"metadata":{"annotations":{"key":"value"},"labels":{"key":"value"}},"spec":{"containers":[{"env":[{"name":"MY_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}}],"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"machine-learning","resources":{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}}],"initContainers":[{"command":["sh","-c","until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"],"image":"busybox:1.28","name":"init-myservice"}]}}}]}},"replicas":1},{"generictemplate":{"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"labels":{"odh-ray-cluster-service":"quicktest-head-svc"},"name":"ray-dashboard-quicktest","namespace":"default"},"spec":{"port":{"targetPort":"dashboard"},"to":{"kind":"Service","name":"quicktest-head-svc"}}},"replica":1}],"Items":[]}}}\n'
                     },
                     "creationTimestamp": "2023-02-22T16:26:07Z",
                     "generation": 4,
                     "managedFields": [
                         {
-                            "apiVersion": "mcad.ibm.com/v1beta1",
+                            "apiVersion": "codeflare.dev/v1beta1",
                             "fieldsType": "FieldsV1",
                             "fieldsV1": {
                                 "f:spec": {
@@ -958,7 +958,7 @@ def get_aw_obj(group, version, namespace, plural):
                             "time": "2023-02-22T16:26:07Z",
                         },
                         {
-                            "apiVersion": "mcad.ibm.com/v1beta1",
+                            "apiVersion": "codeflare.dev/v1beta1",
                             "fieldsType": "FieldsV1",
                             "fieldsV1": {
                                 "f:metadata": {
@@ -1022,7 +1022,7 @@ def get_aw_obj(group, version, namespace, plural):
                                     "kind": "RayCluster",
                                     "metadata": {
                                         "labels": {
-                                            "appwrapper.mcad.ibm.com": "quicktest1",
+                                            "appwrapper.codeflare.dev": "quicktest1",
                                             "controller-tools.k8s.io": "1.0",
                                         },
                                         "name": "quicktest1",
@@ -1243,17 +1243,17 @@ def get_aw_obj(group, version, namespace, plural):
                 },
             },
             {
-                "apiVersion": "mcad.ibm.com/v1beta1",
+                "apiVersion": "codeflare.dev/v1beta1",
                 "kind": "AppWrapper",
                 "metadata": {
                     "annotations": {
-                        "kubectl.kubernetes.io/last-applied-configuration": '{"apiVersion":"mcad.ibm.com/v1beta1","kind":"AppWrapper","metadata":{"annotations":{},"name":"quicktest2","namespace":"ns"},"spec":{"priority":9,"resources":{"GenericItems":[{"custompodresources":[{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}},{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}],"generictemplate":{"apiVersion":"ray.io/v1alpha1","kind":"RayCluster","metadata":{"labels":{"appwrapper.mcad.ibm.com":"quicktest2","controller-tools.k8s.io":"1.0"},"name":"quicktest2","namespace":"ns"},"spec":{"autoscalerOptions":{"idleTimeoutSeconds":60,"imagePullPolicy":"Always","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"upscalingMode":"Default"},"enableInTreeAutoscaling":false,"headGroupSpec":{"rayStartParams":{"block":"true","dashboard-host":"0.0.0.0","num-gpus":"0"},"serviceType":"ClusterIP","template":{"spec":{"containers":[{"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","imagePullPolicy":"Always","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"ray-head","ports":[{"containerPort":6379,"name":"gcs"},{"containerPort":8265,"name":"dashboard"},{"containerPort":10001,"name":"client"}],"resources":{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}}}]}}},"rayVersion":"1.12.0","workerGroupSpecs":[{"groupName":"small-group-quicktest","maxReplicas":1,"minReplicas":1,"rayStartParams":{"block":"true","num-gpus":"0"},"replicas":1,"template":{"metadata":{"annotations":{"key":"value"},"labels":{"key":"value"}},"spec":{"containers":[{"env":[{"name":"MY_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}}],"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"machine-learning","resources":{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}}],"initContainers":[{"command":["sh","-c","until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"],"image":"busybox:1.28","name":"init-myservice"}]}}}]}},"replicas":1},{"generictemplate":{"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"labels":{"odh-ray-cluster-service":"quicktest-head-svc"},"name":"ray-dashboard-quicktest","namespace":"default"},"spec":{"port":{"targetPort":"dashboard"},"to":{"kind":"Service","name":"quicktest-head-svc"}}},"replica":1}],"Items":[]}}}\n'
+                        "kubectl.kubernetes.io/last-applied-configuration": '{"apiVersion":"codeflare.dev/v1beta1","kind":"AppWrapper","metadata":{"annotations":{},"name":"quicktest2","namespace":"ns"},"spec":{"priority":9,"resources":{"GenericItems":[{"custompodresources":[{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}},{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"replicas":1,"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}],"generictemplate":{"apiVersion":"ray.io/v1alpha1","kind":"RayCluster","metadata":{"labels":{"appwrapper.codeflare.dev":"quicktest2","controller-tools.k8s.io":"1.0"},"name":"quicktest2","namespace":"ns"},"spec":{"autoscalerOptions":{"idleTimeoutSeconds":60,"imagePullPolicy":"Always","resources":{"limits":{"cpu":"500m","memory":"512Mi"},"requests":{"cpu":"500m","memory":"512Mi"}},"upscalingMode":"Default"},"enableInTreeAutoscaling":false,"headGroupSpec":{"rayStartParams":{"block":"true","dashboard-host":"0.0.0.0","num-gpus":"0"},"serviceType":"ClusterIP","template":{"spec":{"containers":[{"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","imagePullPolicy":"Always","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"ray-head","ports":[{"containerPort":6379,"name":"gcs"},{"containerPort":8265,"name":"dashboard"},{"containerPort":10001,"name":"client"}],"resources":{"limits":{"cpu":2,"memory":"8G","nvidia.com/gpu":0},"requests":{"cpu":2,"memory":"8G","nvidia.com/gpu":0}}}]}}},"rayVersion":"1.12.0","workerGroupSpecs":[{"groupName":"small-group-quicktest","maxReplicas":1,"minReplicas":1,"rayStartParams":{"block":"true","num-gpus":"0"},"replicas":1,"template":{"metadata":{"annotations":{"key":"value"},"labels":{"key":"value"}},"spec":{"containers":[{"env":[{"name":"MY_POD_IP","valueFrom":{"fieldRef":{"fieldPath":"status.podIP"}}}],"image":"ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103","lifecycle":{"preStop":{"exec":{"command":["/bin/sh","-c","ray stop"]}}},"name":"machine-learning","resources":{"limits":{"cpu":1,"memory":"2G","nvidia.com/gpu":0},"requests":{"cpu":1,"memory":"2G","nvidia.com/gpu":0}}}],"initContainers":[{"command":["sh","-c","until nslookup $RAY_IP.$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace).svc.cluster.local; do echo waiting for myservice; sleep 2; done"],"image":"busybox:1.28","name":"init-myservice"}]}}}]}},"replicas":1},{"generictemplate":{"apiVersion":"route.openshift.io/v1","kind":"Route","metadata":{"labels":{"odh-ray-cluster-service":"quicktest-head-svc"},"name":"ray-dashboard-quicktest","namespace":"default"},"spec":{"port":{"targetPort":"dashboard"},"to":{"kind":"Service","name":"quicktest-head-svc"}}},"replica":1}],"Items":[]}}}\n'
                     },
                     "creationTimestamp": "2023-02-22T16:26:07Z",
                     "generation": 4,
                     "managedFields": [
                         {
-                            "apiVersion": "mcad.ibm.com/v1beta1",
+                            "apiVersion": "codeflare.dev/v1beta1",
                             "fieldsType": "FieldsV1",
                             "fieldsV1": {
                                 "f:spec": {
@@ -1281,7 +1281,7 @@ def get_aw_obj(group, version, namespace, plural):
                             "time": "2023-02-22T16:26:07Z",
                         },
                         {
-                            "apiVersion": "mcad.ibm.com/v1beta1",
+                            "apiVersion": "codeflare.dev/v1beta1",
                             "fieldsType": "FieldsV1",
                             "fieldsV1": {
                                 "f:metadata": {
@@ -1345,7 +1345,7 @@ def get_aw_obj(group, version, namespace, plural):
                                     "kind": "RayCluster",
                                     "metadata": {
                                         "labels": {
-                                            "appwrapper.mcad.ibm.com": "quicktest2",
+                                            "appwrapper.codeflare.dev": "quicktest2",
                                             "controller-tools.k8s.io": "1.0",
                                         },
                                         "name": "quicktest2",
@@ -2155,7 +2155,7 @@ def test_AWManager_creation():
 
 
 def arg_check_aw_apply_effect(group, version, namespace, plural, body, *args):
-    assert group == "mcad.ibm.com"
+    assert group == "codeflare.dev"
     assert version == "v1beta1"
     assert namespace == "ns"
     assert plural == "appwrappers"
@@ -2166,7 +2166,7 @@ def arg_check_aw_apply_effect(group, version, namespace, plural, body, *args):
 
 
 def arg_check_aw_del_effect(group, version, namespace, plural, name, *args):
-    assert group == "mcad.ibm.com"
+    assert group == "codeflare.dev"
     assert version == "v1beta1"
     assert namespace == "ns"
     assert plural == "appwrappers"


### PR DESCRIPTION
# Issue link
#272 

# What changes have been made
API groups for AW changed from mcad.ibm.com to codeflare.dev

# Verification steps
Verify no remaining files with mcad.ibm.com, and all have switched to codeflare.dev

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change
