### PR TITLE
Replaced load_kube_config() with config_check()

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -455,8 +455,8 @@ def get_current_namespace():  # pragma: no cover
 
 def get_cluster(cluster_name: str, namespace: str = "default"):
     try:
-        config.load_kube_config()
-        api_instance = client.CustomObjectsApi()
+        config_check()
+        api_instance = client.CustomObjectsApi(api_config_handler())
         rcs = api_instance.list_namespaced_custom_object(
             group="ray.io",
             version="v1alpha1",
@@ -477,7 +477,7 @@ def get_cluster(cluster_name: str, namespace: str = "default"):
 # private methods
 def _get_ingress_domain():
     try:
-        config.load_kube_config()
+        config_check()
         api_client = client.CustomObjectsApi(api_config_handler())
         ingress = api_client.get_cluster_custom_object(
             "config.openshift.io", "v1", "ingresses", "cluster"

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -23,7 +23,7 @@ import argparse
 import uuid
 from kubernetes import client, config
 from .kube_api_helpers import _kube_api_error_handling
-from ..cluster.auth import api_config_handler
+from ..cluster.auth import api_config_handler, config_check
 
 
 def read_template(template):
@@ -268,7 +268,7 @@ def enable_local_interactive(resources, cluster_name, namespace):
 
     command = command.replace("deployment-name", cluster_name)
     try:
-        config.load_kube_config()
+        config_check()
         api_client = client.CustomObjectsApi(api_config_handler())
         ingress = api_client.get_cluster_custom_object(
             "config.openshift.io", "v1", "ingresses", "cluster"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes #336 
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Replaced mentions of `config.load_kube_config()` with `config_check()` in `cluster.py` and `generate_yaml.py`
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Make a copy of your `~/.kube/config` file and delete the original
* Run through the [local_interactive](https://github.com/project-codeflare/codeflare-sdk/blob/main/demo-notebooks/additional-demos/local_interactive.ipynb) Jupytr Notebook
* Authenticate with your token + server
* You should be able to run through the entire notbook without errors
*  The `get_cluster()` function should also work without errors this way
## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change
