### PR TITLE
Fixing python tests badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codeflare-SDK
 
-[![Python application](https://github.com/project-codeflare/codeflare-sdk/actions/workflows/python-app.yml/badge.svg?branch=main)](https://github.com/project-codeflare/codeflare-sdk/actions/workflows/python-app.yml)
+[![Python application](https://github.com/project-codeflare/codeflare-sdk/actions/workflows/unit-tests.yml/badge.svg?branch=main)](https://github.com/project-codeflare/codeflare-sdk/actions/workflows/unit-tests.yml)
 ![coverage badge](./coverage.svg)
 
 An intuitive, easy-to-use python interface for batch resource requesting, access, job submission, and observation. Simplifying the developer's life while enabling access to high-performance compute resources, either in the cloud or on-prem.


### PR DESCRIPTION
Following on from this [PR](https://github.com/project-codeflare/codeflare-sdk/pull/305) I noticed that the python tests badge on the SDK readme was not rendering, this was due to a filename being updated and the url used in the readme not being updated. 
This PR updates the required url and the badge is now showing as expected.
