### PR TITLE
Check for dashboard readiness after cluster is ready

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -274,19 +274,27 @@ class Cluster:
         dashboard_ready = False
         status = None
         time = 0
-        while not ready or not dashboard_ready:
+        while not ready:
             status, ready = self.status(print_to_console=False)
-            dashboard_ready = self.is_dashboard_ready()
             if status == CodeFlareClusterStatus.UNKNOWN:
                 print(
                     "WARNING: Current cluster status is unknown, have you run cluster.up yet?"
                 )
-            if not ready or not dashboard_ready:
+            if not ready:
                 if timeout and time >= timeout:
-                    raise TimeoutError(f"wait() timed out after waiting {timeout}s")
+                    raise TimeoutError(f"wait() timed out after waiting {timeout}s for cluster to be ready")
                 sleep(5)
                 time += 5
-        print("Requested cluster and dashboard are up and running!")
+        print("Requested cluster is up and running!")
+
+        while not dashboard_ready:
+            dashboard_ready = self.is_dashboard_ready()
+            if not dashboard_ready:
+                if timeout and time >= timeout:
+                    raise TimeoutError(f"wait() timed out after waiting {timeout}s for dashboard to be ready")
+                sleep(5)
+                time += 5
+        print("Dashboard is ready!")
 
     def details(self, print_to_console: bool = True) -> RayCluster:
         cluster = _copy_to_ray(self)

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -264,7 +264,7 @@ class Cluster:
         else:
             return False
 
-    def wait_ready(self, timeout: Optional[int] = None):
+    def wait_ready(self, timeout: Optional[int] = None, dashboard_check: bool = True):
         """
         Waits for requested cluster to be ready, up to an optional timeout (s).
         Checks every five seconds.
@@ -282,19 +282,24 @@ class Cluster:
                 )
             if not ready:
                 if timeout and time >= timeout:
-                    raise TimeoutError(f"wait() timed out after waiting {timeout}s for cluster to be ready")
+                    raise TimeoutError(
+                        f"wait() timed out after waiting {timeout}s for cluster to be ready"
+                    )
                 sleep(5)
                 time += 5
         print("Requested cluster is up and running!")
 
-        while not dashboard_ready:
+        while dashboard_check and not dashboard_ready:
             dashboard_ready = self.is_dashboard_ready()
             if not dashboard_ready:
                 if timeout and time >= timeout:
-                    raise TimeoutError(f"wait() timed out after waiting {timeout}s for dashboard to be ready")
+                    raise TimeoutError(
+                        f"wait() timed out after waiting {timeout}s for dashboard to be ready"
+                    )
                 sleep(5)
                 time += 5
-        print("Dashboard is ready!")
+        if dashboard_ready:
+            print("Dashboard is ready!")
 
     def details(self, print_to_console: bool = True) -> RayCluster:
         cluster = _copy_to_ray(self)

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1796,6 +1796,12 @@ def test_wait_ready(mocker, capsys):
         captured.out
         == "Waiting for requested resources to be set up...\nRequested cluster is up and running!\nDashboard is ready!\n"
     )
+    cf.wait_ready(dashboard_check=False)
+    captured = capsys.readouterr()
+    assert (
+        captured.out
+        == "Waiting for requested resources to be set up...\nRequested cluster is up and running!\n"
+    )
 
 
 def test_jobdefinition_coverage():

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1794,7 +1794,7 @@ def test_wait_ready(mocker, capsys):
     captured = capsys.readouterr()
     assert (
         captured.out
-        == "Waiting for requested resources to be set up...\nRequested cluster and dashboard are up and running!\n"
+        == "Waiting for requested resources to be set up...\nRequested cluster is up and running!\nDashboard is ready!\n"
     )
 
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Resolves #355 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
The check for `is_dashboard_ready` is now performed after the cluster is ready.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

1. Run `cluster.up()` and `cluster.wait_ready()` together.
2. See no errors.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->