### PR TITLE
add: abstraction to remove appwrapper visiblilty from NB console. 

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -71,8 +71,10 @@ class Cluster:
         """
         self.config = config
         self.app_wrapper_yaml = self.create_app_wrapper()
-        self.app_wrapper_name = self.app_wrapper_yaml.split(".")[0]
         self._job_submission_client = None
+        self.app_wrapper_name = self.app_wrapper_yaml.replace(".yaml", "").split("/")[
+            -1
+        ]
 
     @property
     def _client_headers(self):

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -19,6 +19,7 @@ This sub-module exists primarily to be used internally by the Cluster object
 
 import yaml
 import sys
+import os
 import argparse
 import uuid
 from kubernetes import client, config
@@ -506,8 +507,14 @@ def disable_raycluster_tls(resources):
 
 
 def write_user_appwrapper(user_yaml, output_file_name):
+    # Create the directory if it doesn't exist
+    directory_path = os.path.dirname(output_file_name)
+    if not os.path.exists(directory_path):
+        os.makedirs(directory_path)
+
     with open(output_file_name, "w") as outfile:
         yaml.dump(user_yaml, outfile, default_flow_style=False)
+
     print(f"Written to: {output_file_name}")
 
 
@@ -675,7 +682,8 @@ def generate_appwrapper(
     if openshift_oauth:
         enable_openshift_oauth(user_yaml, cluster_name, namespace)
 
-    outfile = appwrapper_name + ".yaml"
+    directory_path = os.path.expanduser("~/.codeflare/appwrapper/")
+    outfile = os.path.join(directory_path, appwrapper_name + ".yaml")
     if not mcad:
         write_components(user_yaml, outfile)
     else:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -22,6 +22,7 @@ import re
 import uuid
 
 parent = Path(__file__).resolve().parents[1]
+aw_dir = os.path.expanduser("~/.codeflare/appwrapper/")
 sys.path.append(str(parent) + "/src")
 
 from kubernetes import client, config
@@ -254,10 +255,12 @@ def test_config_creation():
 
 def test_cluster_creation(mocker):
     cluster = createClusterWithConfig(mocker)
-    assert cluster.app_wrapper_yaml == "unit-test-cluster.yaml"
+    assert cluster.app_wrapper_yaml == f"{aw_dir}unit-test-cluster.yaml"
     assert cluster.app_wrapper_name == "unit-test-cluster"
     assert filecmp.cmp(
-        "unit-test-cluster.yaml", f"{parent}/tests/test-case.yaml", shallow=True
+        f"{aw_dir}unit-test-cluster.yaml",
+        f"{parent}/tests/test-case.yaml",
+        shallow=True,
     )
 
 
@@ -270,10 +273,10 @@ def test_cluster_creation_no_mcad(mocker):
     config.name = "unit-test-cluster-ray"
     config.mcad = False
     cluster = Cluster(config)
-    assert cluster.app_wrapper_yaml == "unit-test-cluster-ray.yaml"
+    assert cluster.app_wrapper_yaml == f"{aw_dir}unit-test-cluster-ray.yaml"
     assert cluster.app_wrapper_name == "unit-test-cluster-ray"
     assert filecmp.cmp(
-        "unit-test-cluster-ray.yaml",
+        f"{aw_dir}unit-test-cluster-ray.yaml",
         f"{parent}/tests/test-case-no-mcad.yamls",
         shallow=True,
     )
@@ -293,10 +296,12 @@ def test_cluster_creation_priority(mocker):
         return_value={"spec": {"domain": "apps.cluster.awsroute.org"}},
     )
     cluster = Cluster(config)
-    assert cluster.app_wrapper_yaml == "prio-test-cluster.yaml"
+    assert cluster.app_wrapper_yaml == f"{aw_dir}prio-test-cluster.yaml"
     assert cluster.app_wrapper_name == "prio-test-cluster"
     assert filecmp.cmp(
-        "prio-test-cluster.yaml", f"{parent}/tests/test-case-prio.yaml", shallow=True
+        f"{aw_dir}prio-test-cluster.yaml",
+        f"{parent}/tests/test-case-prio.yaml",
+        shallow=True,
     )
 
 
@@ -314,7 +319,7 @@ def test_default_cluster_creation(mocker):
     )
     cluster = Cluster(default_config)
 
-    assert cluster.app_wrapper_yaml == "unit-test-default-cluster.yaml"
+    assert cluster.app_wrapper_yaml == f"{aw_dir}unit-test-default-cluster.yaml"
     assert cluster.app_wrapper_name == "unit-test-default-cluster"
     assert cluster.config.namespace == "opendatahub"
 
@@ -344,13 +349,13 @@ def arg_check_apply_effect(group, version, namespace, plural, body, *args):
     if plural == "appwrappers":
         assert group == "workload.codeflare.dev"
         assert version == "v1beta1"
-        with open("unit-test-cluster.yaml") as f:
+        with open(f"{aw_dir}unit-test-cluster.yaml") as f:
             aw = yaml.load(f, Loader=yaml.FullLoader)
         assert body == aw
     elif plural == "rayclusters":
         assert group == "ray.io"
         assert version == "v1alpha1"
-        with open("unit-test-cluster-ray.yaml") as f:
+        with open(f"{aw_dir}unit-test-cluster-ray.yaml") as f:
             yamls = yaml.load_all(f, Loader=yaml.FullLoader)
             for resource in yamls:
                 if resource["kind"] == "RayCluster":
@@ -358,7 +363,7 @@ def arg_check_apply_effect(group, version, namespace, plural, body, *args):
     elif plural == "routes":
         assert group == "route.openshift.io"
         assert version == "v1"
-        with open("unit-test-cluster-ray.yaml") as f:
+        with open(f"{aw_dir}unit-test-cluster-ray.yaml") as f:
             yamls = yaml.load_all(f, Loader=yaml.FullLoader)
             for resource in yamls:
                 if resource["kind"] == "Route":
@@ -2368,7 +2373,7 @@ def parse_j(cmd):
 
 
 def test_AWManager_creation():
-    testaw = AWManager("test.yaml")
+    testaw = AWManager(f"{aw_dir}test.yaml")
     assert testaw.name == "test"
     assert testaw.namespace == "ns"
     assert testaw.submitted == False
@@ -2392,7 +2397,7 @@ def arg_check_aw_apply_effect(group, version, namespace, plural, body, *args):
     assert version == "v1beta1"
     assert namespace == "ns"
     assert plural == "appwrappers"
-    with open("test.yaml") as f:
+    with open(f"{aw_dir}test.yaml") as f:
         aw = yaml.load(f, Loader=yaml.FullLoader)
     assert body == aw
     assert args == tuple()
@@ -2408,7 +2413,7 @@ def arg_check_aw_del_effect(group, version, namespace, plural, name, *args):
 
 
 def test_AWManager_submit_remove(mocker, capsys):
-    testaw = AWManager("test.yaml")
+    testaw = AWManager(f"{aw_dir}test.yaml")
     testaw.remove()
     captured = capsys.readouterr()
     assert (
@@ -2665,13 +2670,12 @@ def test_gen_app_wrapper_with_oauth(mocker: MockerFixture):
 
 # Make sure to always keep this function last
 def test_cleanup():
-    os.remove("unit-test-cluster.yaml")
-    os.remove("prio-test-cluster.yaml")
-    os.remove("unit-test-default-cluster.yaml")
-    os.remove("unit-test-cluster-ray.yaml")
-    os.remove("test.yaml")
-    os.remove("raytest2.yaml")
-    os.remove("quicktest.yaml")
+    os.remove(f"{aw_dir}unit-test-cluster.yaml")
+    os.remove(f"{aw_dir}prio-test-cluster.yaml")
+    os.remove(f"{aw_dir}unit-test-default-cluster.yaml")
+    os.remove(f"{aw_dir}test.yaml")
+    os.remove(f"{aw_dir}raytest2.yaml")
+    os.remove(f"{aw_dir}quicktest.yaml")
     os.remove("tls-cluster-namespace/ca.crt")
     os.remove("tls-cluster-namespace/tls.crt")
     os.remove("tls-cluster-namespace/tls.key")


### PR DESCRIPTION
# Issue link
closes https://github.com/project-codeflare/codeflare-sdk/issues/365

# What changes have been made
To further abstract the appwrapper from a users perspective, they appwrapper generation has been moved to a hidden folder `~/.codeflare/appwrapper/<appwrapper.yaml>.`

# Verification steps
`poetry build` 
Install the new .whl for the sdk in a jupyter notebook. 
Open one of the quick-start demos: `git clone https://github.com/project-codeflare/codeflare-sdk`

Follow the process as usual. 

After your clusterconfiguration ensure this is logged:
`Written to: /opt/app-root/src/.codeflare/appwrapper/<appwrapper.yaml>`

The yaml will no longer appear in the listed files.

From the notebook terminal, you can `cd` to `~/.codeflare/appwrapper/` and then `ls`. This will list the generated .yaml. Feel free to inspect it with `vi <appwrapper-name.yaml>` and ensure the appwrapper name and information is correct. 

Continue with  `cluster.up()` and ensure the appwrapper is applied and raycluster is deployed as expected, with the correct cluster info in the kuberay-operator pod logs.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->