### PR TITLE
refactor: use digest instead of tag for raycluster image

### DIFF
--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -48,7 +48,7 @@ class ClusterConfiguration:
     instascale: bool = False
     mcad: bool = True
     envs: dict = field(default_factory=dict)
-    image: str = "quay.io/project-codeflare/ray:latest-py39-cu118"
+    image: str = "quay.io/project-codeflare/ray@sha256:1ddf39c1bbb182bc9f9c477fa0003902506013f8721f7e203673f965156f5559"
     local_interactive: bool = False
     image_pull_secrets: list = field(default_factory=list)
     dispatch_priority: str = None

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -242,7 +242,10 @@ def test_config_creation():
     assert config.min_cpus == 3 and config.max_cpus == 4
     assert config.min_memory == 5 and config.max_memory == 6
     assert config.num_gpus == 7
-    assert config.image == "quay.io/project-codeflare/ray:latest-py39-cu118"
+    assert (
+        config.image
+        == "quay.io/project-codeflare/ray@sha256:1ddf39c1bbb182bc9f9c477fa0003902506013f8721f7e203673f965156f5559"
+    )
     assert config.template == f"{parent}/src/codeflare_sdk/templates/base-template.yaml"
     assert config.instascale
     assert config.machine_types == ["cpu.small", "gpu.large"]


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

Changing from tag to digest reference for raycluster image

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Confirm that the sha matches the sha from the latest raycluster tag [here](https://quay.io/repository/project-codeflare/ray?tab=tags)

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->