### PR TITLE
Fix No module named "pyarrow"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ codeflare-torchx = "0.6.0.dev1"
 cryptography = "40.0.2"
 executing = "1.2.0"
 pydantic = "< 2"
+pyarrow = ">= 6.0.1, < 7.0.0"
 
 [tool.poetry.group.docs]
 optional = true


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Resolves #417 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Added `pyarrow` to the poetry dependencies.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->


- Checkout this PR (or add the line of code to the pyproject.toml file on latest main branch)
- Install codeflare-sdk in your kubernetes cluster. Probably easiest way is to run `poetry build`, then install the generated wheel with `pip install codeflare_sdk-0.0.0.dev0-py3-none-any.whl`.
- Clone the codeflare-sdk repository.
- Run through the guided-demo notebook `3_basic_interactive.ipynb` where we will set in our ClusterConfiguration instascale to false and GPU to 0 as scaling doesn't occur before the error is encountered. Run the demo until the point where we run `ray.init` and make sure the Ray cluster is up and running.
- No errors encountered.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Manual tests

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->