### PR TITLE
JobDefinition env parameter to specify pip index url and host

### DIFF
--- a/src/codeflare_sdk/job/jobs.py
+++ b/src/codeflare_sdk/job/jobs.py
@@ -22,6 +22,8 @@ from torchx.runner import get_runner, Runner
 from torchx.schedulers.ray_scheduler import RayScheduler
 from torchx.specs import AppHandle, parse_app_handle, AppDryRunInfo
 
+from ..utils.generate_yaml import update_pip_requirements
+
 
 if TYPE_CHECKING:
     from ..cluster.cluster import Cluster
@@ -90,6 +92,12 @@ class DDPJobDefinition(JobDefinition):
         )
         self.image = image
         self.workspace = workspace
+        if "PIP_TRUSTED_HOST" in self.env or "PIP_INDEX_URL" in self.env:
+            update_pip_requirements(self)
+        else:
+            self.env.setdefault("PIP_TRUSTED_HOST", "pypi.org")
+            self.env.setdefault("PIP_INDEX_URL", "https://pypi.org/simple")
+            update_pip_requirements(self)
 
     def _dry_run(self, cluster: "Cluster"):
         j = f"{cluster.config.num_workers}x{max(cluster.config.num_gpus, 1)}"  # # of proc. = # of gpus

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -2091,7 +2091,11 @@ def test_DDPJobDefinition_creation():
     assert ddp.memMB == 1024
     assert ddp.h == None
     assert ddp.j == "2x1"
-    assert ddp.env == {"test": "test"}
+    assert ddp.env == {
+        "PIP_TRUSTED_HOST": "pypi.org",
+        "PIP_INDEX_URL": "https://pypi.org/simple",
+        "test": "test",
+    }
     assert ddp.max_retries == 0
     assert ddp.mounts == []
     assert ddp.rdzv_port == 29500


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Resolves #408 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Created a function that checks for env variables in the DDPJobDefinition, and looks for the `PIP_INDEX_URL` and/or `PIP_TRUSTED_HOST` keys. If these keys are found, pip will leverage the dedicated index location provided with the mentioned env variables.

This allows the user to submit a job with the provided env variables for pip.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- Checkout this PR
- Install codeflare-sdk in your kubernetes cluster. Probably easiest way is to run `poetry build`, then install the generated wheel with `pip install codeflare_sdk-0.0.0.dev0-py3-none-any.whl`.
- Clone the codeflare-sdk repository.
- Run through the guided-demo notebook `2_basic_jobs.ipynb`.
- Add the env vars to the JobDefinition such as this example:
```
jobdef = DDPJobDefinition(
    name="mnisttest",
    script="mnist.py",
    env={"PIP_INDEX_URL": "https://pypi.org/simple", 
        "PIP_TRUSTED_HOST": "pypi.org"},
    # script="mnist_disconnected.py", # training script for disconnected environment
    scheduler_args={"requirements": "requirements.txt"}
)
job = jobdef.submit(cluster)
```
- Go to your dashboard, look for your submitted job, and look at the Runtime environment used:
![image](https://github.com/project-codeflare/codeflare-sdk/assets/73656840/b51feea8-d001-411d-9627-edb0a3bb880a)
- Dependencies are installed from the trusted source provided.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->