### PR TITLE
Added kube exception to is_openshift_cluster

### DIFF
--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -62,9 +62,8 @@ def is_openshift_cluster():
                     return True
         else:
             return False
-    except client.ApiException as e:  # pragma: no cover
-        print(f"Error detecting cluster type defaulting to Kubernetes: {e}")
-        return False
+    except Exception as e:  # pragma: no cover
+        return _kube_api_error_handling(e)
 
 
 def update_dashboard_route(route_item, cluster_name, namespace):


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[Jira issue](https://issues.redhat.com/browse/RHOAIENG-1954)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Replaced old exception for is_openshift_cluster for `_kube_api_error_handling` which will cause authentication errors when a user is not authenticated correctly.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Run a demo notebook without authenticating.
You should get a `Action not permitted, have you put in correct/up-to-date auth credentials?` error.
Run a demo notebook with correct authentication and it should work as expected
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->