### PR TITLE
Added directory creation check for cases where mcad=False

### DIFF
--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -619,6 +619,11 @@ def _create_oauth_sidecar_object(
 
 
 def write_components(user_yaml: dict, output_file_name: str):
+    # Create the directory if it doesn't exist
+    directory_path = os.path.dirname(output_file_name)
+    if not os.path.exists(directory_path):
+        os.makedirs(directory_path)
+
     components = user_yaml.get("spec", "resources")["resources"].get("GenericItems")
     open(output_file_name, "w").close()
     with open(output_file_name, "a") as outfile:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added a conditional statement that will create the `~/.codeflare/appwrapper` directory if it doesn't exist for the `write_components()` function.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Ensure the `~/.codeflare/appwrapper` directory does not exist
Run poetry build on the PR changes and install the whl file
Run through an SDK demo notebook but set `mcad=False` in the cluster configuration.
The folder and yaml file should be present at `~/.codeflare/appwrapper`
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->