### PR TITLE
Update cluster-configuration doc for clarity

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -23,8 +23,10 @@ cluster = Cluster(ClusterConfiguration(
     instascale=False, # Default False
     machine_types=["m5.xlarge", "g4dn.xlarge"],
     ingress_domain="example.com" # Default None, Mandatory for Vanilla Kubernetes Clusters - ingress_domain is ignored on OpenShift Clusters as a route is created.
+    local_interactive=False, # Default False
 ))
 ```
+Note: On OpenShift, the `ingress_domain` is only required when `local_interactive` is enabled. - This may change soon.
 
 Upon creating a cluster configuration with `mcad=True` an appwrapper will be created featuring the Ray Cluster and any Routes, Ingresses or Secrets that are needed to be created along side it.<br>
 From there a user can call `cluster.up()` and `cluster.down()` to create and remove the appwrapper thus creating and removing the Ray Cluster.
@@ -36,7 +38,7 @@ The Ray Cluster and service will be created by KubeRay directly and the other co
 To create a Ray Cluster using the CodeFlare SDK in a Vanilla Kubernetes environment an `ingress_domain` must be passed in the Cluster Configuration.
 This is used for the creation of the Ray Dashboard and Client ingresses.
 
-`ingress_options` can be passed to create a custom Ray Dashboard ingress, `ingress_domain` is still a required variable for the Client ingress.
+`ingress_options` can be passed to create a custom Ray Dashboard ingress, `ingress_domain` is still a required variable for the Client route/ingress.
 An example of `ingress_options` would look like this.
 
 ```

--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -22,7 +22,7 @@ cluster = Cluster(ClusterConfiguration(
     image="quay.io/project-codeflare/ray:latest-py39-cu118", # Mandatory Field
     instascale=False, # Default False
     machine_types=["m5.xlarge", "g4dn.xlarge"],
-    ingress_domain="example.com" # Default None, Mandatory for Kubernetes Clusters
+    ingress_domain="example.com" # Default None, Mandatory for Vanilla Kubernetes Clusters - ingress_domain is ignored on OpenShift Clusters as a route is created.
 ))
 ```
 
@@ -32,8 +32,8 @@ From there a user can call `cluster.up()` and `cluster.down()` to create and rem
 In cases where `mcad=False` a yaml file will be created with the individual Ray Cluster, Route/Ingress and Secret included.<br>
 The Ray Cluster and service will be created by KubeRay directly and the other components will be individually created.
 
-## Ray Cluster Configuration in a Kubernetes environment
-To create a Ray Cluster using the CodeFlare SDK in a Kubernetes environment an `ingress_domain` must be passed in the Cluster Configuration.
+## Ray Cluster Configuration in a Vanilla Kubernetes environment (Non-OpenShift)
+To create a Ray Cluster using the CodeFlare SDK in a Vanilla Kubernetes environment an `ingress_domain` must be passed in the Cluster Configuration.
 This is used for the creation of the Ray Dashboard and Client ingresses.
 
 `ingress_options` can be passed to create a custom Ray Dashboard ingress, `ingress_domain` is still a required variable for the Client ingress.


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Based on the Slack thread: https://redhat-internal.slack.com/archives/C06C5MK3MT9/p1706197906613209

@Bobbins228 and I realised that we should further clarify in the `Cluster-Configuration` documentation that `ingress_domain` is not required when on an OpenShift cluster as a route is created instead, and that it's only mandatory for Vanilla Kubernetes clusters.

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->