### PR TITLE
Fix cluster.status() for Routes

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -1903,6 +1903,7 @@ def route_retrieval(group, version, namespace, plural, name):
 
 def test_list_clusters(mocker, capsys):
     mocker.patch("kubernetes.config.load_kube_config", return_value="ignore")
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
     mocker.patch(
         "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
         side_effect=get_obj_none,


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Resolves: https://issues.redhat.com/browse/RHOAIENG-2274 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Update `_map_to_ray_cluster()` function to get the dashboard address from a route when the SDK detects the user is on OpenShift.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->