### PR TITLE
add: simplified import statements for the codeflare-sdk

### DIFF
--- a/src/codeflare_sdk/__init__.py
+++ b/src/codeflare_sdk/__init__.py
@@ -1,0 +1,18 @@
+from .cluster import (
+    Authentication,
+    KubeConfiguration,
+    TokenAuthentication,
+    KubeConfigFileAuthentication,
+    AWManager,
+    Cluster,
+    ClusterConfiguration,
+    RayClusterStatus,
+    AppWrapperStatus,
+    CodeFlareClusterStatus,
+    RayCluster,
+    AppWrapper,
+)
+
+from .job import JobDefinition, Job, DDPJobDefinition, DDPJob, RayJobClient
+
+from .utils import generate_cert

--- a/src/codeflare_sdk/cluster/__init__.py
+++ b/src/codeflare_sdk/cluster/__init__.py
@@ -1,0 +1,18 @@
+from .auth import (
+    Authentication,
+    KubeConfiguration,
+    TokenAuthentication,
+    KubeConfigFileAuthentication,
+)
+
+from .model import (
+    RayClusterStatus,
+    AppWrapperStatus,
+    CodeFlareClusterStatus,
+    RayCluster,
+    AppWrapper,
+)
+
+from .cluster import Cluster, ClusterConfiguration
+
+from .awload import AWManager

--- a/src/codeflare_sdk/job/__init__.py
+++ b/src/codeflare_sdk/job/__init__.py
@@ -1,0 +1,3 @@
+from .jobs import JobDefinition, Job, DDPJobDefinition, DDPJob
+
+from .ray_jobs import RayJobClient


### PR DESCRIPTION
# Issue link
closes https://issues.redhat.com/browse/RHOAIENG-2109

# What changes have been made
This pr introduces a simplified import approach for the codeflare-sdk. Reducing the nested element of import statements. 
For example: 
```py
    from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
    from codeflare_sdk.cluster.auth import TokenAuthentication
```

Becomes: 
```py
    from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication
```

This pr also contains the relevent updates to documentation and example notebooks.

# Verification steps
Build the sdk and install it on your notebook.
Run through the examples, with the updated import statements, and ensure everything runs.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->