### PR TITLE
Fix component output logs in e2e workflow

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -121,6 +121,8 @@ jobs:
           echo "Running e2e tests..."
           poetry run pytest -v -s ./tests/e2e -m kind > ${CODEFLARE_TEST_OUTPUT_DIR}/pytest_output.log 2>&1
 
+          kubectl config use-context kind-cluster
+
       - name: Print CodeFlare operator logs
         if: always() && steps.deploy.outcome == 'success'
         run: |


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Previously, the artifact logs failed to be generated as they are being requested by the `sdk-user` with limited permissions:
![image](https://github.com/project-codeflare/codeflare-sdk/assets/73656840/3f93645f-944d-47e5-8242-311c904dea9a)


# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
After the e2e run completes, the context is switched back to cluster-admin.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Output logs in e2e workflow should show no errors.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->