### PR TITLE
[WIP] Added mcad bool for Job submission with no cluster

### DIFF
--- a/src/codeflare_sdk/job/jobs.py
+++ b/src/codeflare_sdk/job/jobs.py
@@ -138,7 +138,7 @@ class DDPJobDefinition(JobDefinition):
         if self.scheduler_args is not None:
             if self.scheduler_args.get("namespace") is None:
                 self.scheduler_args["namespace"] = get_current_namespace()
-        scheduler = "kueue_job"
+        scheduler = "kueue"
         if self.mcad == True:
             scheduler = "kubernetes_mcad"
         runner = get_runner()


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes [RHOAIENG-1055](https://issues.redhat.com/browse/RHOAIENG-1055)
linked to https://github.com/pytorch/torchx/pull/822
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added an `mcad` bool which defaults at `False` for Job submission.
When mcad is false we use the `kueue_job` torchx scheduler
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Follow the testing steps in this [PR]( https://github.com/pytorch/torchx/pull/822) but stop after installation.
* Make a change to the `pyproject.toml` file 
    * replace `codeflare-torchx = "0.6.0.dev1"` with `torchx = {path = "/path/to/your/torchx/dist/torchx-0.7.0.dev0-py3-none-any.whl"}`
* run `poetry build` and `pip install --force-reinstall /path/to/your/dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl`
* Run the jobs demo notebook with this configuration:
```
from codeflare_sdk.job.jobs import DDPJobDefinition
jobdef = DDPJobDefinition(
    name="mnistjob",
    script="mnist.py",
    # script="mnist_disconnected.py", # training script for disconnected environment
    scheduler_args={"namespace": "default", "local_queue": "YOUR LOCAL QUEUE"}, # ADD "priority_class":"kueue-priority-class-name" for testing priority
    j="1x1",
    gpu=0,
    cpu=1,
    max_retries=3,
    memMB=8000,
    image="quay.io/mcampbel/mnist-image:v0.0",
    mcad=False
)
job = jobdef.submit()
```
* From there you can test logs and status as well as cancel like the mcad version.
 
Note: If you are testing priority you need a workload priority class and the workload associated with the job should have the priority you set included.

Note 2: This PR is purely for testing the kueue job scheduler but will be converted to a "real" PR for adding Kueue Job submission when the [codeflare-sdk torchx](https://github.com/project-codeflare/torchx) is synced with the upstream torchx repo
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->