### PR TITLE
odh configmap configuration to default template

### DIFF
--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -157,6 +157,18 @@ spec:
                   - name: server-cert
                     mountPath: "/home/ray/workspace/tls"
                     readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 initContainers:
                 - command:
                   - sh
@@ -181,6 +193,20 @@ spec:
                   optional: false
                 - name: server-cert
                   emptyDir: {}
+                - name: odh-trusted-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    optional: true
+                - name: odh-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    optional: true
           workerGroupSpecs:
           # the pod replicas in this group typed worker
           - replicas: 3
@@ -277,6 +303,18 @@ spec:
                   - name: server-cert
                     mountPath: "/home/ray/workspace/tls"
                     readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 volumes:
                 - name: ca-vol
                   secret:
@@ -284,6 +322,20 @@ spec:
                   optional: false
                 - name: server-cert
                   emptyDir: {}
+                - name: odh-trusted-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    optional: true
+                - name: odh-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    optional: true
     - replicas: 1
       generictemplate:
         apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
I also changed the removal of raycluster tls objects so it is done by name rather than all at once

# Issue link
https://redhat-internal.slack.com/archives/C06C5MK3MT9/p1708358451702429
https://issues.redhat.com/browse/RHOAIENG-3325

# What changes have been made
I added optional configmaps to the default ray cluster template that match those generated by odh. I also changed the disabling of tls so that it removes only specific entries from volumes and volumeMounts that way it doesn't delete the volumes created in this PR

# Verification steps
attempt to run a script that talks to endpoint with custom ca-cert and make sure it works without error or warning.
I'm not completely sure of a good way to test this

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->