### PR TITLE
odh configmap configuration to default template - Fixed tests

### DIFF
--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -157,6 +157,18 @@ spec:
                   - name: server-cert
                     mountPath: "/home/ray/workspace/tls"
                     readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 initContainers:
                 - command:
                   - sh
@@ -181,6 +193,20 @@ spec:
                   optional: false
                 - name: server-cert
                   emptyDir: {}
+                - name: odh-trusted-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    optional: true
+                - name: odh-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    optional: true
           workerGroupSpecs:
           # the pod replicas in this group typed worker
           - replicas: 3
@@ -277,6 +303,18 @@ spec:
                   - name: server-cert
                     mountPath: "/home/ray/workspace/tls"
                     readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 volumes:
                 - name: ca-vol
                   secret:
@@ -284,6 +322,20 @@ spec:
                   optional: false
                 - name: server-cert
                   emptyDir: {}
+                - name: odh-trusted-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    optional: true
+                - name: odh-ca-cert
+                  configMap:
+                    name: odh-trusted-ca-bundle
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    optional: true
     - replicas: 1
       generictemplate:
         apiVersion: networking.k8s.io/v1

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -157,16 +157,16 @@ spec:
                   - name: server-cert
                     mountPath: "/home/ray/workspace/tls"
                     readOnly: true
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
                 initContainers:
@@ -303,16 +303,16 @@ spec:
                   - name: server-cert
                     mountPath: "/home/ray/workspace/tls"
                     readOnly: true
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
                 volumes:

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -77,8 +77,41 @@ spec:
               cpu: 2
               memory: 8G
               nvidia.com/gpu: 0
+          volumeMounts:
+          - mountPath: /home/ray/workspace/tls
+            name: server-cert
+            readOnly: true
+          - mountPath: /etc/pki/tls/certs
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
         imagePullSecrets:
         - name: unit-test-pull-secret
+        volumes:
+        - emptyDir: {}
+          name: server-cert
+        - configMap:
+            items:
+            - key: ca-bundle.crt
+              path: odh-custom-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-trusted-ca-cert
+        - configMap:
+            items:
+            - key: odh-ca-bundle.crt
+              path: odh-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-ca-cert
   rayVersion: 2.7.0
   workerGroupSpecs:
   - groupName: small-group-unit-test-cluster-ray
@@ -136,8 +169,41 @@ spec:
               cpu: 3
               memory: 5G
               nvidia.com/gpu: 7
+          volumeMounts:
+          - mountPath: /home/ray/workspace/tls
+            name: server-cert
+            readOnly: true
+          - mountPath: /etc/pki/tls/certs
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
         imagePullSecrets:
         - name: unit-test-pull-secret
+        volumes:
+        - emptyDir: {}
+          name: server-cert
+        - configMap:
+            items:
+            - key: ca-bundle.crt
+              path: odh-custom-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-trusted-ca-cert
+        - configMap:
+            items:
+            - key: odh-ca-bundle.crt
+              path: odh-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-ca-cert
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -81,16 +81,16 @@ spec:
           - mountPath: /home/ray/workspace/tls
             name: server-cert
             readOnly: true
-          - mountPath: /etc/pki/tls/certs
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
             name: odh-trusted-ca-cert
             subPath: odh-trusted-ca-bundle.crt
-          - mountPath: /etc/ssl/certs
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
             name: odh-trusted-ca-cert
             subPath: odh-trusted-ca-bundle.crt
-          - mountPath: /etc/pki/tls/certs
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
             name: odh-ca-cert
             subPath: odh-ca-bundle.crt
-          - mountPath: /etc/ssl/certs
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
             name: odh-ca-cert
             subPath: odh-ca-bundle.crt
         imagePullSecrets:
@@ -173,16 +173,16 @@ spec:
           - mountPath: /home/ray/workspace/tls
             name: server-cert
             readOnly: true
-          - mountPath: /etc/pki/tls/certs
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
             name: odh-trusted-ca-cert
             subPath: odh-trusted-ca-bundle.crt
-          - mountPath: /etc/ssl/certs
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
             name: odh-trusted-ca-cert
             subPath: odh-trusted-ca-bundle.crt
-          - mountPath: /etc/pki/tls/certs
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
             name: odh-ca-cert
             subPath: odh-ca-bundle.crt
-          - mountPath: /etc/ssl/certs
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
             name: odh-ca-cert
             subPath: odh-ca-bundle.crt
         imagePullSecrets:

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -107,9 +107,42 @@ spec:
                       cpu: 2
                       memory: 8G
                       nvidia.com/gpu: 0
+                  volumeMounts:
+                  - mountPath: /home/ray/workspace/tls
+                    name: server-cert
+                    readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 imagePullSecrets:
                 - name: unit-test-pull-secret
                 priorityClassName: default
+                volumes:
+                - emptyDir: {}
+                  name: server-cert
+                - configMap:
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-trusted-ca-cert
+                - configMap:
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-ca-cert
           rayVersion: 2.7.0
           workerGroupSpecs:
           - groupName: small-group-prio-test-cluster
@@ -167,9 +200,42 @@ spec:
                       cpu: 3
                       memory: 5G
                       nvidia.com/gpu: 7
+                  volumeMounts:
+                  - mountPath: /home/ray/workspace/tls
+                    name: server-cert
+                    readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 imagePullSecrets:
                 - name: unit-test-pull-secret
                 priorityClassName: default
+                volumes:
+                - emptyDir: {}
+                  name: server-cert
+                - configMap:
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-trusted-ca-cert
+                - configMap:
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-ca-cert
       replicas: 1
     - generictemplate:
         apiVersion: networking.k8s.io/v1

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -111,16 +111,16 @@ spec:
                   - mountPath: /home/ray/workspace/tls
                     name: server-cert
                     readOnly: true
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
                 imagePullSecrets:
@@ -204,16 +204,16 @@ spec:
                   - mountPath: /home/ray/workspace/tls
                     name: server-cert
                     readOnly: true
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
                 imagePullSecrets:

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -106,8 +106,41 @@ spec:
                       cpu: 2
                       memory: 8G
                       nvidia.com/gpu: 0
+                  volumeMounts:
+                  - mountPath: /home/ray/workspace/tls
+                    name: server-cert
+                    readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 imagePullSecrets:
                 - name: unit-test-pull-secret
+                volumes:
+                - emptyDir: {}
+                  name: server-cert
+                - configMap:
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-trusted-ca-cert
+                - configMap:
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-ca-cert
           rayVersion: 2.7.0
           workerGroupSpecs:
           - groupName: small-group-unit-test-cluster
@@ -165,8 +198,41 @@ spec:
                       cpu: 3
                       memory: 5G
                       nvidia.com/gpu: 7
+                  volumeMounts:
+                  - mountPath: /home/ray/workspace/tls
+                    name: server-cert
+                    readOnly: true
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-trusted-ca-cert
+                    subPath: odh-trusted-ca-bundle.crt
+                  - mountPath: /etc/pki/tls/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
+                  - mountPath: /etc/ssl/certs
+                    name: odh-ca-cert
+                    subPath: odh-ca-bundle.crt
                 imagePullSecrets:
                 - name: unit-test-pull-secret
+                volumes:
+                - emptyDir: {}
+                  name: server-cert
+                - configMap:
+                    items:
+                    - key: ca-bundle.crt
+                      path: odh-custom-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-trusted-ca-cert
+                - configMap:
+                    items:
+                    - key: odh-ca-bundle.crt
+                      path: odh-ca-bundle.crt
+                    name: odh-trusted-ca-bundle
+                    optional: true
+                  name: odh-ca-cert
       replicas: 1
     - generictemplate:
         apiVersion: networking.k8s.io/v1

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -110,16 +110,16 @@ spec:
                   - mountPath: /home/ray/workspace/tls
                     name: server-cert
                     readOnly: true
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
                 imagePullSecrets:
@@ -202,16 +202,16 @@ spec:
                   - mountPath: /home/ray/workspace/tls
                     name: server-cert
                     readOnly: true
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
                     name: odh-trusted-ca-cert
                     subPath: odh-trusted-ca-bundle.crt
-                  - mountPath: /etc/pki/tls/certs
+                  - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
-                  - mountPath: /etc/ssl/certs
+                  - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
                     name: odh-ca-cert
                     subPath: odh-ca-bundle.crt
                 imagePullSecrets:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -2709,10 +2709,26 @@ def test_enable_local_interactive(mocker):
     volumes = [
         {
             "name": "ca-vol",
-            "secret": {"secretName": f"ca-secret-{cluster_name}"},
+            "secret": {"secretName": "ca-secret-test-enable-local"},
             "optional": False,
         },
         {"name": "server-cert", "emptyDir": {}},
+        {
+            "name": "odh-trusted-ca-cert",
+            "configMap": {
+                "name": "odh-trusted-ca-bundle",
+                "items": [{"key": "ca-bundle.crt", "path": "odh-custom-ca-bundle.crt"}],
+                "optional": True,
+            },
+        },
+        {
+            "name": "odh-ca-cert",
+            "configMap": {
+                "name": "odh-trusted-ca-bundle",
+                "items": [{"key": "odh-ca-bundle.crt", "path": "odh-ca-bundle.crt"}],
+                "optional": True,
+            },
+        },
     ]
     tls_env = [
         {"name": "RAY_USE_TLS", "value": "1"},
@@ -2740,6 +2756,9 @@ def test_enable_local_interactive(mocker):
         head_group_spec["template"]["spec"]["initContainers"][0]["volumeMounts"]
         == volume_mounts
     )
+    print(head_group_spec["template"]["spec"]["volumes"])
+    print("----------------")
+    print(volumes)
     assert head_group_spec["template"]["spec"]["volumes"] == volumes
 
     # 2. workerGroupSpec has the initContainers command to generated TLS cert from the mounted CA cert.


### PR DESCRIPTION
Fixed the failing unit tests on Kevin's [PR](https://github.com/project-codeflare/codeflare-sdk/pull/462)
-------------------------------------
I also changed the removal of raycluster tls objects so it is done by name rather than all at once

# Issue link
https://redhat-internal.slack.com/archives/C06C5MK3MT9/p1708358451702429
https://issues.redhat.com/browse/RHOAIENG-3325

# What changes have been made
I added optional configmaps to the default ray cluster template that match those generated by odh. I also changed the disabling of tls so that it removes only specific entries from volumes and volumeMounts that way it doesn't delete the volumes created in this PR

# Verification steps
attempt to run a script that talks to endpoint with custom ca-cert and make sure it works without error or warning.
I'm not completely sure of a good way to test this

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->