### PR TITLE
Use Kueue as default

### DIFF
--- a/src/codeflare_sdk/__init__.py
+++ b/src/codeflare_sdk/__init__.py
@@ -12,6 +12,8 @@ from .cluster import (
     RayCluster,
     AppWrapper,
     get_cluster,
+    list_all_queued,
+    list_all_clusters,
 )
 
 from .job import JobDefinition, Job, DDPJobDefinition, DDPJob, RayJobClient

--- a/src/codeflare_sdk/cluster/__init__.py
+++ b/src/codeflare_sdk/cluster/__init__.py
@@ -13,6 +13,12 @@ from .model import (
     AppWrapper,
 )
 
-from .cluster import Cluster, ClusterConfiguration, get_cluster
+from .cluster import (
+    Cluster,
+    ClusterConfiguration,
+    get_cluster,
+    list_all_queued,
+    list_all_clusters,
+)
 
 from .awload import AWManager

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -595,7 +595,7 @@ def list_all_clusters(namespace: str, print_to_console: bool = True):
 
 def list_all_queued(namespace: str, print_to_console: bool = True, mcad: bool = False):
     """
-    Returns (and prints by default) a list of all currently queued-up Ray Clusters or AppWrappers
+    Returns (and prints by default) a list of all currently queued-up Ray Clusters
     in a given namespace.
     """
     if mcad:

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -46,7 +46,7 @@ class ClusterConfiguration:
     num_gpus: int = 0
     template: str = f"{dir}/templates/base-template.yaml"
     instascale: bool = False
-    mcad: bool = True
+    mcad: bool = False
     envs: dict = field(default_factory=dict)
     image: str = ""
     local_interactive: bool = False
@@ -60,3 +60,5 @@ class ClusterConfiguration:
             print(
                 "Warning: TLS verification has been disabled - Endpoint checks will be bypassed"
             )
+
+    local_queue: str = None

--- a/src/codeflare_sdk/cluster/model.py
+++ b/src/codeflare_sdk/cluster/model.py
@@ -32,6 +32,7 @@ class RayClusterStatus(Enum):
     UNHEALTHY = "unhealthy"
     FAILED = "failed"
     UNKNOWN = "unknown"
+    SUSPENDED = "suspended"
 
 
 class AppWrapperStatus(Enum):
@@ -59,6 +60,7 @@ class CodeFlareClusterStatus(Enum):
     QUEUEING = 4
     FAILED = 5
     UNKNOWN = 6
+    SUSPENDED = 7
 
 
 @dataclass

--- a/src/codeflare_sdk/utils/pretty_print.py
+++ b/src/codeflare_sdk/utils/pretty_print.py
@@ -56,6 +56,30 @@ def print_app_wrappers_status(app_wrappers: List[AppWrapper], starting: bool = F
     console.print(Panel.fit(table))
 
 
+def print_ray_clusters_status(app_wrappers: List[AppWrapper], starting: bool = False):
+    if not app_wrappers:
+        print_no_resources_found()
+        return  # shortcircuit
+
+    console = Console()
+    table = Table(
+        box=box.ASCII_DOUBLE_HEAD,
+        title="[bold] :rocket: Cluster Queue Status :rocket:",
+    )
+    table.add_column("Name", style="cyan", no_wrap=True)
+    table.add_column("Status", style="magenta")
+
+    for app_wrapper in app_wrappers:
+        name = app_wrapper.name
+        status = app_wrapper.status.value
+        if starting:
+            status += " (starting)"
+        table.add_row(name, status)
+        table.add_row("")  # empty row for spacing
+
+    console.print(Panel.fit(table))
+
+
 def print_cluster_status(cluster: RayCluster):
     "Pretty prints the status of a passed-in cluster"
     if not cluster:

--- a/tests/e2e/mnist_raycluster_sdk_oauth_test.py
+++ b/tests/e2e/mnist_raycluster_sdk_oauth_test.py
@@ -52,6 +52,7 @@ class TestRayClusterSDKOauth:
                 instascale=False,
                 image=ray_image,
                 write_to_file=True,
+                mcad=True,
             )
         )
 

--- a/tests/e2e/mnist_raycluster_sdk_test.py
+++ b/tests/e2e/mnist_raycluster_sdk_test.py
@@ -52,6 +52,7 @@ class TestMNISTRayClusterSDK:
                 instascale=False,
                 image=ray_image,
                 write_to_file=True,
+                mcad=True,
             )
         )
 

--- a/tests/e2e/start_ray_cluster.py
+++ b/tests/e2e/start_ray_cluster.py
@@ -22,6 +22,7 @@ cluster = Cluster(
         num_gpus=0,
         instascale=False,
         image=ray_image,
+        mcad=True,
     )
 )
 

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -6,7 +6,7 @@ metadata:
     sdk.codeflare.dev/local_interactive: 'False'
   labels:
     controller-tools.k8s.io: '1.0'
-    workload.codeflare.dev/appwrapper: unit-test-cluster-ray
+    kueue.x-k8s.io/queue-name: local-queue-default
   name: unit-test-cluster-ray
   namespace: ns
 spec:

--- a/tests/unit_test_support.py
+++ b/tests/unit_test_support.py
@@ -43,6 +43,7 @@ def createClusterConfig():
         min_memory=5,
         max_memory=6,
         num_gpus=7,
+        mcad=True,
         instascale=True,
         machine_types=["cpu.small", "gpu.large"],
         image_pull_secrets=["unit-test-pull-secret"],


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[RHOAIENG-1058](https://issues.redhat.com/browse/RHOAIENG-1058)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
KubeRay and Kueue are now the primary resources responsible for creating Ray Clusters through the SDK.
`mcad=False` by default meaning Ray Clusters are created via Kube Ray and Routes/Ingresses are created seperately.

The local queue label is applied to the Ray Cluster when `mcad=False`.
The SDK will try to gather the default local queue's name by reading the annotation `"kueue.x-k8s.io/default-queue":"true"` from the local queue. If the SDK is unsuccessful it will raise an error asking for the LQ name to be specified in the `ClusterConfiguration`.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
There are two ways to test this.
1. SDK gathers the default local queue name
2. User provides the local queue name
## 1: SDK gathers the default local queue name
* Create a Local Queue with the new annotation (or add the annotation to your own LQ).
```
apiVersion: kueue.x-k8s.io/v1beta1
kind: LocalQueue
metadata:
    namespace: ns
    name: local_queue_name
    annotations:
      "kueue.x-k8s.io/default-queue": "true"
spec:
  clusterQueue: cluster_queue_name
```
* Run through a default notebook. 
* A yaml file will be generated with the `kueue.x-k8s.io/queue-name: LQ_NAME` label
* Create the Ray Cluster
* Check if a Workload was created for the Ray Cluster
## 2: User provides the Local Queue name
Note: This method is taken into account over the SDK gathering the Local Queue name
* Run through a demo notebook
* Add the parameter `local_queue="LOCAL_QUEUE_NAME"` to the `ClusterConfiguration`
* Check the generated yaml file for the appropriate label 
* Create the Ray Cluster
* Check if a Workload was created for the Ray Cluster
## Other Changes
The status for RayClusters includes suspended now.
Altered `list_all_queued` and `list_all_clusters` to reflect this.
Added the functions above to the simple import scheme.

Note: This PR should not be merged until [RHOAIENG-1056](https://issues.redhat.com/browse/RHOAIENG-1056) and [RHOAIENG-3270](https://issues.redhat.com/browse/RHOAIENG-3270) are merged.
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->