### PR TITLE
add an automated CI workflow to sync ODH-notebooks with latest codefl…

### DIFF
--- a/.github/workflows/odh-notebooks-sync.yml
+++ b/.github/workflows/odh-notebooks-sync.yml
@@ -1,0 +1,128 @@
+# The aim of this GitHub workflow is to update the pipfile to sync with Codeflare-SDK release.
+name: Sync ODH-notebooks with codeflare-sdk release
+on:
+  workflow_dispatch:
+    inputs:
+      upstream-repository-organization:
+        required: true
+        description: "Owner of target upstream notebooks repository used to open a PR against"
+        default: "opendatahub-io"
+
+      codeflare-repository-organization:
+        required: true
+        description: "Owner of origin notebooks repository used to open a PR"
+        default: "project-codeflare"
+
+      codeflare_sdk_release_version:
+        required: true
+        description: "Provide version of the Codeflare-SDK release"
+
+env:
+  BRANCH_NAME: main
+  CODEFLARE_RELEASE_VERSION: ${{ github.event.inputs.codeflare_sdk_release_version }}
+  UPDATER_BRANCH: odh-sync-updater-${{ github.run_id }}
+  UPSTREAM_OWNER: ${{ github.event.inputs.upstream-repository-organization }}
+  REPO_OWNER: ${{ github.event.inputs.codeflare-repository-organization }}
+  REPO_NAME: notebooks
+  GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository and Sync
+        run: |
+          git clone https://x-access-token:${GITHUB_TOKEN}@github.com/$REPO_OWNER/$REPO_NAME.git $REPO_NAME
+          cd $REPO_NAME
+          git remote add upstream https://github.com/$UPSTREAM_OWNER/$REPO_NAME.git
+          git config --global user.email "138894154+codeflare-machine-account@users.noreply.github.com"
+          git config --global user.name "codeflare-machine-account"
+          git remote -v
+          git pull upstream main && git push origin main
+
+      - name: Setup Python environment
+        uses: actions/setup-python@v4
+        with:
+          python-version: |
+            3.8
+            3.9
+
+      - name: Install pipenv and pip-versions
+        run: pip install pipenv pip-versions
+
+      - name: Update Pipfiles in accordance with Codeflare-SDK latest release
+        run: |
+          package_name=codeflare-sdk
+          # Get the list of available versions for the package
+          if ! versions=$(pipenv run pip-versions list $package_name);then
+            echo "Failed to retrieve versions for $package_name"
+            exit 1
+          fi
+          # Check if the desired version exists in the list
+          if echo "$versions" | grep -q "${CODEFLARE_RELEASE_VERSION}"; then
+            echo "Version ${CODEFLARE_RELEASE_VERSION} is available for $package_name"
+            # list all Pipfile paths having Codeflare-SDK listed
+            paths+=($(grep -rl "${package_name} = \"~=.*\""))
+            # Extracting only directories from file paths, excluding a `.gitworkflow` directory
+            directories=()
+            exclude_directories=(
+              ".git/objects/pack"
+              ".github/workflows/",
+            )
+            for path in "${paths[@]}"; do
+              current_dir=$(dirname "$path")
+              #Check if current_dir is not in exclude_directories list
+              if [[ ! "${exclude_directories[@]}" =~ "$current_dir" ]]; then
+                #Check if Pipfile exists in current_dir
+                if [ -f "$current_dir/Pipfile" ];then
+                  directories+=("$current_dir")
+                fi
+              fi
+            done
+            # Remove duplicates
+            directories=($(echo "${directories[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' '))
+            # Print the directories for verification
+            echo "Directories (Start updating Pipfile in these below directories in accordance with Codeflare-SDK latest release):"
+            for dir in "${directories[@]}"; do
+              echo "- $dir"
+            done
+            # iterate over the directories and update Pipfile
+            counter=0
+            total=${#directories[@]}
+            for dir in "${directories[@]}"; do
+              counter=$((counter+1))
+              echo "--Processing directory $counter '$dir' of total $total"
+              cd "$dir" && pipenv install ${package_name}~="${CODEFLARE_RELEASE_VERSION}" && pipenv --rm && cd -
+              echo "$((total-counter)) directories remaining.."
+            done
+          else
+            versions_list=$(echo "$versions" | tr '\n' '   ' | sed 's/, $//')
+            versions="${versions_list%,}"
+            echo "Version '${CODEFLARE_RELEASE_VERSION}' is not available for $package_name"
+            echo "Available versions for $package_name: $versions"
+            exit 1
+          fi
+
+      - name: Push changes
+        run: |
+          cd $REPO_NAME
+          git add . && git status && git checkout -b ${{ env.UPDATER_BRANCH }} && \
+          git commit -am "Updated notebooks via ${{ env.UPDATER_BRANCH }} GitHub action" --signoff  &&
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/$REPO_OWNER/$REPO_NAME.git
+          git push origin ${{ env.UPDATER_BRANCH }}
+
+      - name: Create Pull Request
+        run: |
+          gh pr create --repo $UPSTREAM_OWNER/$REPO_NAME \
+            --title "$pr_title" \
+            --body "$pr_body" \
+            --head $REPO_OWNER:$UPDATER_BRANCH \
+            --base $BRANCH_NAME
+        env:
+          pr_title: "[Digest Updater Action] Update notebook's pipfile to sync with Codeflare-SDK release"
+          pr_body: |
+            :rocket: This is an automated Pull Request.
+
+            This PR updates the `Pipfile` to sync with latest Codeflare-SDK release.
+
+            :exclamation: **IMPORTANT NOTE**: Remember to delete the ` ${{ env.UPDATER_BRANCH }}` branch after merging the changes

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,3 +100,15 @@ jobs:
               env:
                 GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
               shell: bash
+
+            - name: Sync ODH Notebooks
+              run: |
+                gh workflow run odh-notebooks-sync.yml \
+                  --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-sdk \
+                  --ref ${{ github.ref }} \
+                  --field upstream-repository-organization=opendatahub-io
+                  --field codeflare-repository-organization=${{ github.event.inputs.codeflare-repository-organization }} \
+                  --field codeflare_sdk_release_version=${{ github.event.inputs.release-version }}
+              env:
+                GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
+              shell: bash


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[RHOAIENG-3756](https://issues.redhat.com/browse/RHOAIENG-3756)

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Add step to sync ODH notebooks with Codeflare-SDK release by creating automated PR for Project-Codeflare-notebooks repository with latest Cddeflare-SDK release version

Related PR : https://github.com/project-codeflare/codeflare-operator/pull/482

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
A test run in fork results in the following automated PR changes :
[Successful test build ](https://github.com/abhijeet-dhumal/codeflare-sdk/actions/runs/8065068305/job/22030161646#logs)
[Generated automated test PR](https://github.com/sutaakar/notebooks/pull/10)
[Incase Codeflare-SDK version doesn't exist](https://github.com/abhijeet-dhumal/codeflare-sdk/actions/runs/8063089657/job/22024208957#step:6:82)

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->