### PR TITLE
fix: get_cluster logic

### DIFF
--- a/src/codeflare_sdk/__init__.py
+++ b/src/codeflare_sdk/__init__.py
@@ -11,6 +11,7 @@ from .cluster import (
     CodeFlareClusterStatus,
     RayCluster,
     AppWrapper,
+    get_cluster,
 )
 
 from .job import JobDefinition, Job, DDPJobDefinition, DDPJob, RayJobClient

--- a/src/codeflare_sdk/cluster/__init__.py
+++ b/src/codeflare_sdk/cluster/__init__.py
@@ -13,6 +13,6 @@ from .model import (
     AppWrapper,
 )
 
-from .cluster import Cluster, ClusterConfiguration
+from .cluster import Cluster, ClusterConfiguration, get_cluster
 
 from .awload import AWManager

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -510,10 +510,12 @@ class Cluster:
             if "orderedinstance" in rc["metadata"]["labels"]
             else []
         )
-        local_interactive = (
-            "volumeMounts"
-            in rc["spec"]["workerGroupSpecs"][0]["template"]["spec"]["containers"][0]
-        )
+        for volume in rc["spec"]["workerGroupSpecs"][0]["template"]["spec"]["volumes"]:
+            if volume["name"] == "ca-vol":
+                local_interactive = True
+                break
+            else:
+                local_interactive = False
         if local_interactive:
             ingress_domain = get_ingress_domain_from_client(
                 rc["metadata"]["name"], rc["metadata"]["namespace"]

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -515,14 +515,14 @@ class Cluster:
         else:
             local_interactive = False
         if "codeflare.dev/oauth" in rc["metadata"]["annotations"]:
-            if rc["metadata"]["annotations"]["codeflare.dev/oauth"] == "True":
-                openshift_oauth = True
+            openshift_oauth = (
+                rc["metadata"]["annotations"]["codeflare.dev/oauth"] == "True"
+            )
         else:
             for container in rc["spec"]["headGroupSpec"]["template"]["spec"][
                 "containers"
             ]:
-                if "oauth-proxy" in container["name"]:
-                    openshift_oauth = True
+                openshift_oauth = "oauth-proxy" in container["name"]
         machine_types = (
             rc["metadata"]["labels"]["orderedinstance"].split("_")
             if "orderedinstance" in rc["metadata"]["labels"]

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -502,7 +502,9 @@ class Cluster:
             to_return["requirements"] = requirements
         return to_return
 
-    def from_k8_cluster_object(rc, mcad=True, ingress_domain=None, ingress_options={}, write_to_file=False):
+    def from_k8_cluster_object(
+        rc, mcad=True, ingress_domain=None, ingress_options={}, write_to_file=False
+    ):
         config_check()
         if (
             rc["metadata"]["annotations"]["sdk.codeflare.dev/local_interactive"]

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -509,7 +509,7 @@ class Cluster:
         openshift_oauth = False
         if (
             rc["metadata"]["annotations"]["sdk.codeflare.dev/local_interactive"]
-            == "true"
+            == "True"
         ):
             local_interactive = True
         else:
@@ -677,7 +677,7 @@ def get_cluster(
             mcad = _check_aw_exists(cluster_name, namespace)
             ingress_host = None
             ingress_options = {}
-            if is_openshift_cluster() == False:
+            if not is_openshift_cluster():
                 try:
                     config_check()
                     api_instance = client.NetworkingV1Api(api_config_handler())

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -40,6 +40,8 @@ spec:
         apiVersion: ray.io/v1
         kind: RayCluster
         metadata:
+          annotations:
+            sdk.codeflare.dev/local_interactive: "false"
           labels:
             workload.codeflare.dev/appwrapper: "aw-kuberay"
             controller-tools.k8s.io: "1.0"

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -41,7 +41,7 @@ spec:
         kind: RayCluster
         metadata:
           annotations:
-            sdk.codeflare.dev/local_interactive: "false"
+            sdk.codeflare.dev/local_interactive: "False"
           labels:
             workload.codeflare.dev/appwrapper: "aw-kuberay"
             controller-tools.k8s.io: "1.0"

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -463,7 +463,7 @@ def enable_local_interactive(resources, cluster_name, namespace, ingress_domain)
     )
     item["generictemplate"]["metadata"]["annotations"][
         "sdk.codeflare.dev/local_interactive"
-    ] = "true"
+    ] = "True"
     item["generictemplate"]["metadata"]["annotations"][
         "sdk.codeflare.dev/ingress_domain"
     ] = ingress_domain

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -461,6 +461,12 @@ def enable_local_interactive(resources, cluster_name, namespace, ingress_domain)
         namespace,
         ingress_domain,
     )
+    item["generictemplate"]["metadata"]["annotations"][
+        "sdk.codeflare.dev/local_interactive"
+    ] = "true"
+    item["generictemplate"]["metadata"]["annotations"][
+        "sdk.codeflare.dev/ingress_domain"
+    ] = ingress_domain
 
     item["generictemplate"]["spec"]["headGroupSpec"]["template"]["spec"][
         "initContainers"

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -473,6 +473,13 @@ def enable_local_interactive(resources, cluster_name, namespace, ingress_domain)
     ][0].get("command")[2] = command
 
 
+def apply_ingress_domain_annotation(resources, ingress_domain):
+    item = resources["resources"].get("GenericItems")[0]
+    item["generictemplate"]["metadata"]["annotations"][
+        "sdk.codeflare.dev/ingress_domain"
+    ] = ingress_domain
+
+
 def del_from_list_by_name(l: list, target: typing.List[str]) -> list:
     return [x for x in l if x["name"] not in target]
 
@@ -740,6 +747,9 @@ def generate_appwrapper(
         ingress_options,
         ingress_domain,
     )
+    if ingress_domain is not None:
+        apply_ingress_domain_annotation(resources, ingress_domain)
+
     if local_interactive:
         enable_local_interactive(resources, cluster_name, namespace, ingress_domain)
     else:

--- a/tests/test-case-bad.yaml
+++ b/tests/test-case-bad.yaml
@@ -32,6 +32,8 @@ spec:
         apiVersion: ray.io/v1
         kind: RayCluster
         metadata:
+          annotations:
+            sdk.codeflare.dev/local_interactive: 'false'
           labels:
             workload.codeflare.dev/appwrapper: unit-test-cluster
             controller-tools.k8s.io: '1.0'

--- a/tests/test-case-bad.yaml
+++ b/tests/test-case-bad.yaml
@@ -33,7 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           annotations:
-            sdk.codeflare.dev/local_interactive: 'false'
+            sdk.codeflare.dev/local_interactive: 'False'
           labels:
             workload.codeflare.dev/appwrapper: unit-test-cluster
             controller-tools.k8s.io: '1.0'

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -4,7 +4,7 @@ kind: RayCluster
 metadata:
   annotations:
     sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
-    sdk.codeflare.dev/local_interactive: 'false'
+    sdk.codeflare.dev/local_interactive: 'False'
   labels:
     controller-tools.k8s.io: '1.0'
     workload.codeflare.dev/appwrapper: unit-test-cluster-ray

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -3,6 +3,7 @@ apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
   annotations:
+    sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
     sdk.codeflare.dev/local_interactive: 'false'
   labels:
     controller-tools.k8s.io: '1.0'

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -2,6 +2,8 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  annotations:
+    sdk.codeflare.dev/local_interactive: 'false'
   labels:
     controller-tools.k8s.io: '1.0'
     workload.codeflare.dev/appwrapper: unit-test-cluster-ray

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -34,7 +34,7 @@ spec:
         metadata:
           annotations:
             sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
-            sdk.codeflare.dev/local_interactive: 'false'
+            sdk.codeflare.dev/local_interactive: 'False'
           labels:
             controller-tools.k8s.io: '1.0'
             workload.codeflare.dev/appwrapper: prio-test-cluster

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -33,6 +33,7 @@ spec:
         kind: RayCluster
         metadata:
           annotations:
+            sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
             sdk.codeflare.dev/local_interactive: 'false'
           labels:
             controller-tools.k8s.io: '1.0'

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -32,6 +32,8 @@ spec:
         apiVersion: ray.io/v1
         kind: RayCluster
         metadata:
+          annotations:
+            sdk.codeflare.dev/local_interactive: 'false'
           labels:
             controller-tools.k8s.io: '1.0'
             workload.codeflare.dev/appwrapper: prio-test-cluster

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -33,7 +33,7 @@ spec:
         metadata:
           annotations:
             sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
-            sdk.codeflare.dev/local_interactive: 'false'
+            sdk.codeflare.dev/local_interactive: 'False'
           labels:
             controller-tools.k8s.io: '1.0'
             workload.codeflare.dev/appwrapper: unit-test-cluster

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -32,6 +32,7 @@ spec:
         kind: RayCluster
         metadata:
           annotations:
+            sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
             sdk.codeflare.dev/local_interactive: 'false'
           labels:
             controller-tools.k8s.io: '1.0'

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -31,6 +31,8 @@ spec:
         apiVersion: ray.io/v1
         kind: RayCluster
         metadata:
+          annotations:
+            sdk.codeflare.dev/local_interactive: 'false'
           labels:
             controller-tools.k8s.io: '1.0'
             workload.codeflare.dev/appwrapper: unit-test-cluster

--- a/tests/test-default-appwrapper.yaml
+++ b/tests/test-default-appwrapper.yaml
@@ -29,6 +29,8 @@ spec:
         apiVersion: ray.io/v1
         kind: RayCluster
         metadata:
+          annotations:
+            sdk.codeflare.dev/local_interactive: 'false'
           labels:
             controller-tools.k8s.io: '1.0'
             workload.codeflare.dev/appwrapper: unit-test-default-cluster

--- a/tests/test-default-appwrapper.yaml
+++ b/tests/test-default-appwrapper.yaml
@@ -30,6 +30,7 @@ spec:
         kind: RayCluster
         metadata:
           annotations:
+            sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
             sdk.codeflare.dev/local_interactive: 'false'
           labels:
             controller-tools.k8s.io: '1.0'

--- a/tests/test-default-appwrapper.yaml
+++ b/tests/test-default-appwrapper.yaml
@@ -31,7 +31,7 @@ spec:
         metadata:
           annotations:
             sdk.codeflare.dev/ingress_domain: apps.cluster.awsroute.org
-            sdk.codeflare.dev/local_interactive: 'false'
+            sdk.codeflare.dev/local_interactive: 'False'
           labels:
             controller-tools.k8s.io: '1.0'
             workload.codeflare.dev/appwrapper: unit-test-default-cluster

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -959,12 +959,13 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                 "apiVersion": "ray.io/v1",
                 "kind": "RayCluster",
                 "metadata": {
-                    "creationTimestamp": "2023-02-22T16:26:07Z",
+                    "creationTimestamp": "2024-03-05T09:55:37Z",
                     "generation": 1,
                     "labels": {
-                        "workload.codeflare.dev/appwrapper": "quicktest",
+                        "appwrapper.mcad.ibm.com": "quicktest",
                         "controller-tools.k8s.io": "1.0",
                         "resourceName": "quicktest",
+                        "workload.codeflare.dev/appwrapper": "quicktest",
                         "orderedinstance": "m4.xlarge_g4dn.xlarge",
                     },
                     "managedFields": [
@@ -975,13 +976,14 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                                 "f:metadata": {
                                     "f:labels": {
                                         ".": {},
-                                        "f:workload.codeflare.dev/appwrapper": {},
+                                        "f:appwrapper.mcad.ibm.com": {},
                                         "f:controller-tools.k8s.io": {},
                                         "f:resourceName": {},
+                                        "f:workload.codeflare.dev/appwrapper": {},
                                     },
                                     "f:ownerReferences": {
                                         ".": {},
-                                        'k:{"uid":"6334fc1b-471e-4876-8e7b-0b2277679235"}': {},
+                                        'k:{"uid":"a29b1a7a-0992-4860-a8d5-a689a751a3e8"}': {},
                                     },
                                 },
                                 "f:spec": {
@@ -1017,41 +1019,53 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                                         "f:serviceType": {},
                                         "f:template": {
                                             ".": {},
-                                            "f:spec": {".": {}, "f:containers": {}},
+                                            "f:spec": {
+                                                ".": {},
+                                                "f:affinity": {
+                                                    ".": {},
+                                                    "f:nodeAffinity": {
+                                                        ".": {},
+                                                        "f:requiredDuringSchedulingIgnoredDuringExecution": {},
+                                                    },
+                                                },
+                                                "f:imagePullSecrets": {},
+                                                "f:volumes": {},
+                                            },
                                         },
                                     },
                                     "f:rayVersion": {},
                                     "f:workerGroupSpecs": {},
                                 },
                             },
-                            "manager": "mcad-controller",
+                            "manager": "codeflare-operator",
                             "operation": "Update",
-                            "time": "2023-02-22T16:26:07Z",
+                            "time": "2024-03-05T09:55:37Z",
                         },
                         {
-                            "apiVersion": "ray.io/v1",
+                            "apiVersion": "ray.io/v1alpha1",
                             "fieldsType": "FieldsV1",
                             "fieldsV1": {
                                 "f:status": {
                                     ".": {},
-                                    "f:availableWorkerReplicas": {},
                                     "f:desiredWorkerReplicas": {},
                                     "f:endpoints": {
                                         ".": {},
                                         "f:client": {},
                                         "f:dashboard": {},
                                         "f:gcs": {},
+                                        "f:metrics": {},
                                     },
+                                    "f:head": {".": {}, "f:serviceIP": {}},
                                     "f:lastUpdateTime": {},
                                     "f:maxWorkerReplicas": {},
                                     "f:minWorkerReplicas": {},
-                                    "f:state": {},
+                                    "f:observedGeneration": {},
                                 }
                             },
                             "manager": "manager",
                             "operation": "Update",
                             "subresource": "status",
-                            "time": "2023-02-22T16:26:16Z",
+                            "time": "2024-03-05T09:55:37Z",
                         },
                     ],
                     "name": "quicktest",
@@ -1063,11 +1077,11 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                             "controller": True,
                             "kind": "AppWrapper",
                             "name": "quicktest",
-                            "uid": "6334fc1b-471e-4876-8e7b-0b2277679235",
+                            "uid": "a29b1a7a-0992-4860-a8d5-a689a751a3e8",
                         }
                     ],
-                    "resourceVersion": "9482407",
-                    "uid": "44d45d1f-26c8-43e7-841f-831dbd8c1285",
+                    "resourceVersion": "5305674",
+                    "uid": "820d065d-bf0c-4675-b951-d32ea496020e",
                 },
                 "spec": {
                     "autoscalerOptions": {
@@ -1088,9 +1102,50 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                         },
                         "serviceType": "ClusterIP",
                         "template": {
+                            "metadata": {},
                             "spec": {
+                                "affinity": {
+                                    "nodeAffinity": {
+                                        "requiredDuringSchedulingIgnoredDuringExecution": {
+                                            "nodeSelectorTerms": [
+                                                {
+                                                    "matchExpressions": [
+                                                        {
+                                                            "key": "quicktest",
+                                                            "operator": "In",
+                                                            "values": ["quicktest"],
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                },
                                 "containers": [
                                     {
+                                        "env": [
+                                            {
+                                                "name": "MY_POD_IP",
+                                                "valueFrom": {
+                                                    "fieldRef": {
+                                                        "fieldPath": "status.podIP"
+                                                    }
+                                                },
+                                            },
+                                            {"name": "RAY_USE_TLS", "value": "0"},
+                                            {
+                                                "name": "RAY_TLS_SERVER_CERT",
+                                                "value": "/home/ray/workspace/tls/server.crt",
+                                            },
+                                            {
+                                                "name": "RAY_TLS_SERVER_KEY",
+                                                "value": "/home/ray/workspace/tls/server.key",
+                                            },
+                                            {
+                                                "name": "RAY_TLS_CA_CERT",
+                                                "value": "/home/ray/workspace/tls/ca.crt",
+                                            },
+                                        ],
                                         "image": "ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103",
                                         "imagePullPolicy": "Always",
                                         "lifecycle": {
@@ -1134,12 +1189,62 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                                                 "nvidia.com/gpu": 0,
                                             },
                                         },
+                                        "volumeMounts": [
+                                            {
+                                                "mountPath": "/etc/pki/tls/certs/odh-trusted-ca-bundle.crt",
+                                                "name": "odh-trusted-ca-cert",
+                                                "subPath": "odh-trusted-ca-bundle.crt",
+                                            },
+                                            {
+                                                "mountPath": "/etc/ssl/certs/odh-trusted-ca-bundle.crt",
+                                                "name": "odh-trusted-ca-cert",
+                                                "subPath": "odh-trusted-ca-bundle.crt",
+                                            },
+                                            {
+                                                "mountPath": "/etc/pki/tls/certs/odh-ca-bundle.crt",
+                                                "name": "odh-ca-cert",
+                                                "subPath": "odh-ca-bundle.crt",
+                                            },
+                                            {
+                                                "mountPath": "/etc/ssl/certs/odh-ca-bundle.crt",
+                                                "name": "odh-ca-cert",
+                                                "subPath": "odh-ca-bundle.crt",
+                                            },
+                                        ],
                                     }
-                                ]
-                            }
+                                ],
+                                "volumes": [
+                                    {
+                                        "configMap": {
+                                            "items": [
+                                                {
+                                                    "key": "ca-bundle.crt",
+                                                    "path": "odh-trusted-ca-bundle.crt",
+                                                }
+                                            ],
+                                            "name": "odh-trusted-ca-bundle",
+                                            "optional": True,
+                                        },
+                                        "name": "odh-trusted-ca-cert",
+                                    },
+                                    {
+                                        "configMap": {
+                                            "items": [
+                                                {
+                                                    "key": "odh-ca-bundle.crt",
+                                                    "path": "odh-ca-bundle.crt",
+                                                }
+                                            ],
+                                            "name": "odh-trusted-ca-bundle",
+                                            "optional": True,
+                                        },
+                                        "name": "odh-ca-cert",
+                                    },
+                                ],
+                            },
                         },
                     },
-                    "rayVersion": "1.12.0",
+                    "rayVersion": "2.7.0",
                     "workerGroupSpecs": [
                         {
                             "groupName": "small-group-quicktest",
@@ -1147,12 +1252,30 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                             "minReplicas": 1,
                             "rayStartParams": {"block": "true", "num-gpus": "0"},
                             "replicas": 1,
+                            "scaleStrategy": {},
                             "template": {
                                 "metadata": {
                                     "annotations": {"key": "value"},
                                     "labels": {"key": "value"},
                                 },
                                 "spec": {
+                                    "affinity": {
+                                        "nodeAffinity": {
+                                            "requiredDuringSchedulingIgnoredDuringExecution": {
+                                                "nodeSelectorTerms": [
+                                                    {
+                                                        "matchExpressions": [
+                                                            {
+                                                                "key": "quicktest",
+                                                                "operator": "In",
+                                                                "values": ["quicktest"],
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    },
                                     "containers": [
                                         {
                                             "env": [
@@ -1163,7 +1286,20 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                                                             "fieldPath": "status.podIP"
                                                         }
                                                     },
-                                                }
+                                                },
+                                                {"name": "RAY_USE_TLS", "value": "0"},
+                                                {
+                                                    "name": "RAY_TLS_SERVER_CERT",
+                                                    "value": "/home/ray/workspace/tls/server.crt",
+                                                },
+                                                {
+                                                    "name": "RAY_TLS_SERVER_KEY",
+                                                    "value": "/home/ray/workspace/tls/server.key",
+                                                },
+                                                {
+                                                    "name": "RAY_TLS_CA_CERT",
+                                                    "value": "/home/ray/workspace/tls/ca.crt",
+                                                },
                                             ],
                                             "image": "ghcr.io/foundation-model-stack/base:ray2.1.0-py38-gpu-pytorch1.12.0cu116-20221213-193103",
                                             "lifecycle": {
@@ -1190,7 +1326,57 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                                                     "nvidia.com/gpu": 0,
                                                 },
                                             },
+                                            "volumeMounts": [
+                                                {
+                                                    "mountPath": "/etc/pki/tls/certs/odh-trusted-ca-bundle.crt",
+                                                    "name": "odh-trusted-ca-cert",
+                                                    "subPath": "odh-trusted-ca-bundle.crt",
+                                                },
+                                                {
+                                                    "mountPath": "/etc/ssl/certs/odh-trusted-ca-bundle.crt",
+                                                    "name": "odh-trusted-ca-cert",
+                                                    "subPath": "odh-trusted-ca-bundle.crt",
+                                                },
+                                                {
+                                                    "mountPath": "/etc/pki/tls/certs/odh-ca-bundle.crt",
+                                                    "name": "odh-ca-cert",
+                                                    "subPath": "odh-ca-bundle.crt",
+                                                },
+                                                {
+                                                    "mountPath": "/etc/ssl/certs/odh-ca-bundle.crt",
+                                                    "name": "odh-ca-cert",
+                                                    "subPath": "odh-ca-bundle.crt",
+                                                },
+                                            ],
                                         }
+                                    ],
+                                    "volumes": [
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "ca-bundle.crt",
+                                                        "path": "odh-trusted-ca-bundle.crt",
+                                                    }
+                                                ],
+                                                "name": "odh-trusted-ca-bundle",
+                                                "optional": True,
+                                            },
+                                            "name": "odh-trusted-ca-cert",
+                                        },
+                                        {
+                                            "configMap": {
+                                                "items": [
+                                                    {
+                                                        "key": "odh-ca-bundle.crt",
+                                                        "path": "odh-ca-bundle.crt",
+                                                    }
+                                                ],
+                                                "name": "odh-trusted-ca-bundle",
+                                                "optional": True,
+                                            },
+                                            "name": "odh-ca-cert",
+                                        },
                                     ],
                                 },
                             },
@@ -1198,16 +1384,18 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                     ],
                 },
                 "status": {
-                    "availableWorkerReplicas": 2,
                     "desiredWorkerReplicas": 1,
                     "endpoints": {
                         "client": "10001",
                         "dashboard": "8265",
                         "gcs": "6379",
+                        "metrics": "8080",
                     },
-                    "lastUpdateTime": "2023-02-22T16:26:16Z",
+                    "head": {"serviceIP": "172.30.179.88"},
+                    "lastUpdateTime": "2024-03-05T09:55:37Z",
                     "maxWorkerReplicas": 1,
                     "minWorkerReplicas": 1,
+                    "observedGeneration": 1,
                     "state": "ready",
                 },
             }

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -3434,6 +3434,7 @@ def test_cleanup():
     os.remove(f"{aw_dir}prio-test-cluster.yaml")
     os.remove(f"{aw_dir}test.yaml")
     os.remove(f"{aw_dir}raytest2.yaml")
+    os.remove(f"{aw_dir}unit-test-cluster-ray.yaml")
     os.remove("tls-cluster-namespace/ca.crt")
     os.remove("tls-cluster-namespace/tls.crt")
     os.remove("tls-cluster-namespace/tls.key")

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -978,7 +978,7 @@ def get_ray_obj(group, version, namespace, plural, cls=None):
                     "creationTimestamp": "2024-03-05T09:55:37Z",
                     "generation": 1,
                     "annotations": {
-                        "sdk.codeflare.dev/local_interactive": "true",
+                        "sdk.codeflare.dev/local_interactive": "True",
                         "sdk.codeflare.dev/ingress_domain": "apps.cluster.awsroute.org",
                     },
                     "labels": {
@@ -1535,7 +1535,7 @@ def get_aw_obj(group, version, namespace, plural):
                                     "kind": "RayCluster",
                                     "metadata": {
                                         "annotations": {
-                                            "sdk.codeflare.dev/local_interactive": "false"
+                                            "sdk.codeflare.dev/local_interactive": "False"
                                         },
                                         "labels": {
                                             "workload.codeflare.dev/appwrapper": "quicktest1",
@@ -1866,7 +1866,7 @@ def get_aw_obj(group, version, namespace, plural):
                                     "kind": "RayCluster",
                                     "metadata": {
                                         "annotations": {
-                                            "sdk.codeflare.dev/local_interactive": "false"
+                                            "sdk.codeflare.dev/local_interactive": "False"
                                         },
                                         "labels": {
                                             "workload.codeflare.dev/appwrapper": "quicktest2",
@@ -2138,7 +2138,7 @@ def test_get_cluster_openshift(mocker):
     ]
     mocker.patch("kubernetes.client.ApisApi", return_value=mock_api)
 
-    assert is_openshift_cluster() == True
+    assert is_openshift_cluster()
 
     def custom_side_effect(group, version, namespace, plural, **kwargs):
         if plural == "routes":


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
References [RHOAIENG-4028](https://issues.redhat.com/browse/RHOAIENG-4028)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
The addition of the new volumeMounts has caused the `get_cluster()` function to fail as it assumes the new VMs are the local interactive VMs. 
This makes the function try to recreate the local_interactive related resources which causes the 
```ValueError: ingress_domain is invalid. For creating the client route/ingress please specify an ingress domain``` 
error because `ingress_domain` would not be specified.

Also added simplified import for the `get_cluster()` command. It can now be imported like this.
`from codeflare_sdk import get_cluster`
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Run through a demo notebook and create a Ray Cluster on Kind and OpenShift.
run `cluster = get_cluster(name, namespace)` 
`cluster.down()` and other `cluster.` commands should work.
## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->