### PR TITLE
Fix warning from pytest and increase pretty_print coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,3 @@ markers = [
     "kind",
     "openshift"
 ]
-timeout = 900

--- a/src/codeflare_sdk/utils/pretty_print.py
+++ b/src/codeflare_sdk/utils/pretty_print.py
@@ -70,15 +70,11 @@ def print_cluster_status(cluster: RayCluster):
     )
     name = cluster.name
     dashboard = cluster.dashboard
-    # owned = bool(cluster["userOwned"])
-    owned = True
 
     #'table0' to display the cluster name, status, url, and dashboard link
     table0 = Table(box=None, show_header=False)
-    if owned:
-        table0.add_row("[white on green][bold]Name")
-    else:
-        table0.add_row("")
+
+    table0.add_row("[white on green][bold]Name")
     table0.add_row("[bold underline]" + name, status)
     table0.add_row()
     # fixme harcded to default for now
@@ -119,15 +115,11 @@ def print_clusters(clusters: List[RayCluster]):
         memory = str(cluster.worker_mem_min) + "~" + str(cluster.worker_mem_max)
         cpu = str(cluster.worker_cpu)
         gpu = str(cluster.worker_gpu)
-        # owned = bool(cluster["userOwned"])
-        owned = True
 
         #'table0' to display the cluster name, status, url, and dashboard link
         table0 = Table(box=None, show_header=False)
-        if owned:
-            table0.add_row("[white on green][bold]Name")
-        else:
-            table0.add_row("")
+
+        table0.add_row("[white on green][bold]Name")
         table0.add_row("[bold underline]" + name, status)
         table0.add_row()
         # fixme harcded to default for now


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Issue: https://issues.redhat.com/browse/RHOAIENG-4471 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
![image](https://github.com/project-codeflare/codeflare-sdk/assets/73656840/9c717182-78e1-4da5-83c7-72d75eadd276)

- Warning when running pytest unit tests. This is due to having an unknown option in the `pyproject.toml` file, such as `timeout`.
- Increase pretty_print coverage from 97% to 100%
![image](https://github.com/project-codeflare/codeflare-sdk/assets/73656840/2ca014b8-1700-4743-99fd-97c95b4ad888)


# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
0. `pip install coverage` - if required
1. Run the SDK: `pip install -e .`
2. `coverage run -m --source=src pytest -v tests/unit_test.py`
3. No warnings should be in the output.
4. Run `coverage html`
5. The html link will show the full coverage report.


## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->