### PR TITLE
Fix e2e test output logs on failure

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -121,7 +121,8 @@ jobs:
           echo "Running e2e tests..."
           poetry run pytest -v -s ./tests/e2e -m kind > ${CODEFLARE_TEST_OUTPUT_DIR}/pytest_output.log 2>&1
 
-          kubectl config use-context kind-cluster
+      - name: Switch to kind-cluster context to print logs
+        run: kubectl config use-context kind-cluster
 
       - name: Print CodeFlare operator logs
         if: always() && steps.deploy.outcome == 'success'


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Issue: https://issues.redhat.com/browse/RHOAIENG-4472 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
On failure of the e2e test, the step to switch to `kind-cluster` context to output logs gets skipped. - Causing component logs to not display.

- Added as a separate step in e2e workflow to switch context.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Component logs should be shown at the end of e2e workflow.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->