### PR TITLE
Fix codeflare-sdk python e2e tests to pick timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,4 @@ markers = [
     "kind",
     "openshift"
 ]
+addopts = "--timeout=900"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
closes https://issues.redhat.com/browse/RHOAIENG-4674

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Adjusted pytest section in pyproject.toml file to use timeout option for e2e tests
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Check while running e2e tests timeout is with default `timeout: 900.0s`
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->