### PR TITLE
Add TokenAuthentation step for Ray cluster SDK OAuth Authentication tests

### DIFF
--- a/tests/e2e/mnist_raycluster_sdk_oauth_test.py
+++ b/tests/e2e/mnist_raycluster_sdk_oauth_test.py
@@ -4,7 +4,7 @@ from time import sleep
 
 from torchx.specs.api import AppState, is_terminal
 
-from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
+from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication
 from codeflare_sdk.job.jobs import DDPJobDefinition
 
 import pytest
@@ -29,6 +29,13 @@ class TestRayClusterSDKOauth:
 
     def run_mnist_raycluster_sdk_oauth(self):
         ray_image = get_ray_image()
+
+        auth = TokenAuthentication(
+            token=run_oc_command(["whoami", "--show-token=true"]),
+            server=run_oc_command(["whoami", "--show-server=true"]),
+            skip_tls=True,
+        )
+        auth.login()
 
         cluster = Cluster(
             ClusterConfiguration(

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -1,6 +1,7 @@
 import os
 import random
 import string
+import subprocess
 from kubernetes import client, config
 import kubernetes.client
 
@@ -33,3 +34,14 @@ def initialize_kubernetes_client(self):
     # Initialize Kubernetes client
     self.api_instance = client.CoreV1Api()
     self.custom_api = kubernetes.client.CustomObjectsApi(self.api_instance.api_client)
+
+
+def run_oc_command(args):
+    try:
+        result = subprocess.run(
+            ["oc"] + args, capture_output=True, text=True, check=True
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error executing 'oc {' '.join(args)}': {e}")
+        return None


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
closes https://issues.redhat.com/browse/RHOAIENG-4753
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added TokenAuthentation step for Ray cluster SDK OAuth Authentication test
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Test TestRayClusterSDKOauth in Openshift cluster
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->