### PR TITLE
Fix output logs by switching to kind-cluster context

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -123,6 +123,7 @@ jobs:
           poetry run pytest -v -s ./tests/e2e -m kind > ${CODEFLARE_TEST_OUTPUT_DIR}/pytest_output.log 2>&1
 
       - name: Switch to kind-cluster context to print logs
+        if: always() && steps.deploy.outcome == 'success'
         run: kubectl config use-context kind-cluster
 
       - name: Print CodeFlare operator logs


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-5131 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
This was previously attempted to be fixed, however when the e2e test fails, the step to `Switch to kind-cluster context` is skipped due to previous step failure.
- With this change, the step to switch context will always be made, enabling to print component logs.

As seen/tested here: https://github.com/project-codeflare/codeflare-sdk/actions/runs/8560772513/job/23460511229?pr=495 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->