### PR TITLE
Refactor e2e tests to use kueue

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -10,8 +10,10 @@ Pre-requisite for KinD clusters: please add in your local `/etc/hosts` file `127
   ```
   make kind-e2e
   export CLUSTER_HOSTNAME=kind
-  make deploy -e IMG=quay.io/project-codeflare/codeflare-operator:v1.1.0
   make setup-e2e
+  make deploy -e IMG=quay.io/project-codeflare/codeflare-operator:v1.3.0
+
+  For running tests locally on Kind cluster, we need to disable `rayDashboardOAuthEnabled` in `codeflare-operator-config` ConfigMap and then restart CodeFlare Operator
   ```
 
   - **(Optional)** - Create and add `sdk-user` with limited permissions to the cluster to run through the e2e tests:
@@ -53,9 +55,13 @@ Pre-requisite for KinD clusters: please add in your local `/etc/hosts` file `127
 
   ```
 
+  - Install the latest development version of kueue
+  ```
+  kubectl apply --server-side -k "github.com/opendatahub-io/kueue/config/rhoai?ref=dev"
+  ```
 
 - Test Phase:
-   - Once we have the codeflare-operator and kuberay-operator running and ready, we can run the e2e test on the codeflare-sdk repository:
+   - Once we have the codeflare-operator, kuberay-operator and kueue running and ready, we can run the e2e test on the codeflare-sdk repository:
   ```
   poetry install --with test,docs
   poetry run pytest -v -s ./tests/e2e/mnist_raycluster_sdk_test.py
@@ -67,11 +73,18 @@ Pre-requisite for KinD clusters: please add in your local `/etc/hosts` file `127
 - Setup Phase:
   - Pull the [codeflare-operator repo](https://github.com/project-codeflare/codeflare-operator) and run the following make targets:
   ```
-  make deploy -e IMG=quay.io/project-codeflare/codeflare-operator:v1.1.0
+
   make setup-e2e
+  make deploy -e IMG=quay.io/project-codeflare/codeflare-operator:v1.3.0
   ```
+
+  - Install the latest development version of kueue
+  ```
+  kubectl apply --server-side -k "github.com/opendatahub-io/kueue/config/rhoai?ref=dev"
+  ```
+
 - Test Phase:
-   - Once we have the codeflare-operator and kuberay-operator running and ready, we can run the e2e test on the codeflare-sdk repository:
+   - Once we have the codeflare-operator, kuberay-operator and kueue running and ready, we can run the e2e test on the codeflare-sdk repository:
   ```
   poetry install --with test,docs
   poetry run pytest -v -s ./tests/e2e/mnist_raycluster_sdk_test.py

--- a/tests/e2e/kueue_resources_setup.sh
+++ b/tests/e2e/kueue_resources_setup.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+name=${name:-cluster-queue-mnist}
+flavor=${flavor:-default-flavor-mnist}
+local_queue_name=${local_queue_name:-local-queue-mnist}
+namespace=$1
+
+echo "Applying Cluster Queue"
+
+cat <<EOF | kubectl apply --server-side -f -
+    apiVersion: kueue.x-k8s.io/v1beta1
+    kind: ClusterQueue
+    metadata:
+        name: $name
+    spec:
+      namespaceSelector: {}
+      resourceGroups:
+      - coveredResources: ["cpu", "memory", "nvidia.com/gpu"]
+        flavors:
+        - name: "default-flavor-mnist"
+          resources:
+          - name: "cpu"
+            nominalQuota: 9
+          - name: "memory"
+            nominalQuota: 36Gi
+          - name: "nvidia.com/gpu"
+            nominalQuota: 0
+EOF
+echo "Cluster Queue $name applied!"
+
+echo "Applying Resource flavor"
+cat <<EOF | kubectl apply --server-side -f -
+    apiVersion: kueue.x-k8s.io/v1beta1
+    kind: ResourceFlavor
+    metadata:
+        name: $flavor
+EOF
+echo "Resource flavor $flavor applied!"
+
+echo "Applying local queue"
+
+cat <<EOF | kubectl apply --server-side -f -
+    apiVersion: kueue.x-k8s.io/v1beta1
+    kind: LocalQueue
+    metadata:
+        namespace: $namespace
+        name: $local_queue_name
+        annotations:
+          "kueue.x-k8s.io/default-queue": "true"
+    spec:
+      clusterQueue: $name
+EOF
+echo "Local Queue $local_queue_name applied!"

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -4,6 +4,7 @@ import string
 import subprocess
 from kubernetes import client, config
 import kubernetes.client
+import subprocess
 
 
 def get_ray_image():
@@ -45,3 +46,9 @@ def run_oc_command(args):
     except subprocess.CalledProcessError as e:
         print(f"Error executing 'oc {' '.join(args)}': {e}")
         return None
+
+
+def create_kueue_resources(self):
+    # Set executable permissions
+    os.chmod("tests/e2e/kueue_resources_setup.sh", 0o755)
+    subprocess.call(["bash", "tests/e2e/kueue_resources_setup.sh", self.namespace])


### PR DESCRIPTION
# Issue link
<https://issues.redhat.com/browse/RHOAIENG-5239>
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
Refactored e2e tests to use kueue and not mcad. 
Added steps to create kueue resources such as cluster queue, resource flavour and local queue.

# Verification steps
Execute e2e tests following https://github.com/project-codeflare/codeflare-sdk/blob/main/docs/e2e.md 


## Checks
- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->