### PR TITLE
Add enableIngress and set to false by default

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -546,7 +546,7 @@ class Cluster:
     ):
         if self.config.write_to_file:
             with open(self.app_wrapper_yaml) as f:
-                yamls = yaml.load_all(f, Loader=yaml.FullLoader)
+                yamls = list(yaml.load_all(f, Loader=yaml.FullLoader))
                 for resource in yamls:
                     enable_ingress = (
                         resource.get("spec", {})
@@ -559,8 +559,6 @@ class Cluster:
                             f"Forbidden: RayCluster '{name}' has 'enableIngress' set to 'True' or is unset."
                         )
                         return
-                f.seek(0)  # Reset file pointer to the beginning
-                yamls = yaml.load_all(f, Loader=yaml.FullLoader)  # Reload the YAMLs
                 _create_resources(yamls, namespace, api_instance)
         else:
             yamls = yaml.load_all(self.app_wrapper_yaml, Loader=yaml.FullLoader)

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -547,6 +547,20 @@ class Cluster:
         if self.config.write_to_file:
             with open(self.app_wrapper_yaml) as f:
                 yamls = yaml.load_all(f, Loader=yaml.FullLoader)
+                for resource in yamls:
+                    enable_ingress = (
+                        resource.get("spec", {})
+                        .get("headGroupSpec", {})
+                        .get("enableIngress")
+                    )
+                    if resource["kind"] == "RayCluster" and enable_ingress is not False:
+                        name = resource["metadata"]["name"]
+                        print(
+                            f"Forbidden: RayCluster '{name}' has 'enableIngress' set to 'True' or is unset."
+                        )
+                        return
+                f.seek(0)  # Reset file pointer to the beginning
+                yamls = yaml.load_all(f, Loader=yaml.FullLoader)  # Reload the YAMLs
                 _create_resources(yamls, namespace, api_instance)
         else:
             yamls = yaml.load_all(self.app_wrapper_yaml, Loader=yaml.FullLoader)

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -87,6 +87,7 @@ spec:
           headGroupSpec:
             # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
             serviceType: ClusterIP
+            enableIngress: false
             # logical group name, for this called head-group, also can be functional
             # pod type head or worker
             # rayNodeType: head # Not needed since it is under the headgroup

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -23,6 +23,7 @@ spec:
     upscalingMode: Default
   enableInTreeAutoscaling: false
   headGroupSpec:
+    enableIngress: false
     rayStartParams:
       block: 'true'
       dashboard-host: 0.0.0.0

--- a/tests/test-case-prio.yaml
+++ b/tests/test-case-prio.yaml
@@ -53,6 +53,7 @@ spec:
             upscalingMode: Default
           enableInTreeAutoscaling: false
           headGroupSpec:
+            enableIngress: false
             rayStartParams:
               block: 'true'
               dashboard-host: 0.0.0.0

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -52,6 +52,7 @@ spec:
             upscalingMode: Default
           enableInTreeAutoscaling: false
           headGroupSpec:
+            enableIngress: false
             rayStartParams:
               block: 'true'
               dashboard-host: 0.0.0.0

--- a/tests/test-default-appwrapper.yaml
+++ b/tests/test-default-appwrapper.yaml
@@ -50,6 +50,7 @@ spec:
             upscalingMode: Default
           enableInTreeAutoscaling: false
           headGroupSpec:
+            enableIngress: false
             rayStartParams:
               block: 'true'
               dashboard-host: 0.0.0.0


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-5116 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Added `enableIngress` field to `headGroupSpec` and set to false by default.
- Added Forbidden message on attempt to create a RayCluster where the `enableIngress` field is not false.
- The loop iterates over the resources in loaded in yaml file and looks for the RayCluster resource and the enableIngress field. If the enableIngress field is not False, forbidden message is displayed to the user, and if it is False, then we create the resources.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Should be tested with this Kueue PR - [Can be followed here](https://github.com/opendatahub-io/kueue/pull/26#:~:text=for%20your%20reviewer%3A-,Verification%20Steps%3A,-Login%20to%20your)

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->