### PR TITLE
Fix Notebook sync release workflow trigger

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,7 +106,7 @@ jobs:
                 gh workflow run odh-notebooks-sync.yml \
                   --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-sdk \
                   --ref ${{ github.ref }} \
-                  --field upstream-repository-organization=opendatahub-io
+                  --field upstream-repository-organization=opendatahub-io \
                   --field codeflare-repository-organization=${{ github.event.inputs.codeflare-repository-organization }} \
                   --field codeflare_sdk_release_version=${{ github.event.inputs.release-version }}
               env:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
N/A

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
GH workflow to update Notebooks with released SDK was broken. This fix should make it work again.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->