### PR TITLE
Align SDK with Validating Webhook behaviour on enableIngress

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -560,10 +560,10 @@ class Cluster:
                         .get("headGroupSpec", {})
                         .get("enableIngress")
                     )
-                    if resource["kind"] == "RayCluster" and enable_ingress is not False:
+                    if resource["kind"] == "RayCluster" and enable_ingress is True:
                         name = resource["metadata"]["name"]
                         print(
-                            f"Forbidden: RayCluster '{name}' has 'enableIngress' set to 'True' or is unset."
+                            f"Forbidden: RayCluster '{name}' has 'enableIngress' set to 'True'."
                         )
                         return
                 _create_resources(yamls, namespace, api_instance)


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-6504 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Aligned the SDK with the behaviour in the [Validating Webhook](https://github.com/project-codeflare/codeflare-operator/blob/main/pkg/controllers/raycluster_webhook.go#L205-L209), specifically on the `enableIngress` field.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- The user should be able to create a RayCluster resource via the SDK with enableIngress unset or set to `false`.
- The user should not be able to create the RayCluster resource via the SDK with enableIngress set to `true`

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->