### PR TITLE
Adding validation for local_queue provided in cluster config

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -344,6 +344,10 @@ def test_cluster_creation_no_mcad_local_queue(mocker):
         "kubernetes.client.CustomObjectsApi.get_cluster_custom_object",
         return_value={"spec": {"domain": "apps.cluster.awsroute.org"}},
     )
+    mocker.patch(
+        "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
+        return_value=get_local_queue("kueue.x-k8s.io", "v1beta1", "ns", "localqueues"),
+    )
     config = createClusterConfig()
     config.name = "unit-test-cluster-ray"
     config.mcad = False
@@ -3014,6 +3018,10 @@ def test_cluster_throw_for_no_raycluster(mocker: MockerFixture):
     mocker.patch(
         "codeflare_sdk.utils.generate_yaml.get_default_kueue_name",
         return_value="default",
+    )
+    mocker.patch(
+        "codeflare_sdk.utils.generate_yaml.local_queue_exists",
+        return_value="true",
     )
 
     def throw_if_getting_raycluster(group, version, namespace, plural):


### PR DESCRIPTION
# Issue link
[RHOAIENG-7064](https://issues.redhat.com/browse/RHOAIENG-7064)

# What changes have been made
Currently when specifying local_queue, if any value is provided the ray cluster can be created. Added a check to validate local_queue name provided by user in cluster configuration exists.

# Verification steps
 - Install RHOAI with codeflare components set to Managed
 - In a jupyter notebook install codeflare sdk from this branch
 ```
git clone https://github.com/Fiona-Waters/codeflare-sdk.git -b local-queue
cd codeflare-sdk
pip install poetry
poetry install
```
 - Restart the kernal and run through a demo notebook
   - Ensure that you do not have the required annotation for the default local queue set.
- scenario 1
   - Set the local_queue parameter to `foobar` and check that you cannot continue and you see the correct error message.
- scenario 2
   - Provide an existing local_queue name and see that you can continue and create the ray cluster
- scenario 3
   - Comment out the local_queue parameter and see that you get the correct error message.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->