### PR TITLE
Add warning if Kueue CRDs not installed on cluster

### DIFF
--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -321,6 +321,10 @@ def write_components(
         os.makedirs(directory_path)
 
     components = user_yaml.get("spec", "resources")["resources"].get("GenericItems")
+    if local_queue is None:
+        print(
+            "Kueue is not installed or won't be used. The absence of CRDs may lack the necessary functionality."
+        )
     open(output_file_name, "w").close()
     lq_name = local_queue or get_default_kueue_name(namespace)
     cluster_labels = labels
@@ -355,6 +359,10 @@ def load_components(
     components = user_yaml.get("spec", "resources")["resources"].get("GenericItems")
     lq_name = local_queue or get_default_kueue_name(namespace)
     cluster_labels = labels
+    if local_queue is None:
+        print(
+            "Kueue is not installed or won't be used. The absence of CRDs may lack the necessary functionality."
+        )
     for component in components:
         if "generictemplate" in component:
             if (


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[RHOAIENG-6294](https://issues.redhat.com/browse/RHOAIENG-6294)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
A warning has been added to the ClusterConfiguration cell to inform users if Kueue CRDs are not installed on the cluster and local_queue is not provided. In this scenario, users will receive informative logs indicating that the absence of CRDs may result in missing functionality.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Uninstall Kueue and delete any CustomResourceDefinitions (CRDs) that exist (filter for `CustomResourceDefinition` in resources and select `LocalQueue` in the name). Clone this branch into Jupyter Notebook, attempt to create a Ray cluster. In the ClusterConfiguration cell, comment out the `local_queue="local-queue-name"` line. When you run it, you should receive a message indicating that `Kueue is not installed or won't be used. The absence of CRDs may result in missing functionality.`
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->