### PR TITLE
e2e tests: Setup Go version based on CFO go.mod file

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -68,7 +68,8 @@ jobs:
       - name: Set Go
         uses: actions/setup-go@v5
         with:
-          go-version: v1.20
+          go-version-file: './codeflare-operator/go.mod'
+          cache-dependency-path: "./codeflare-operator/go.sum"
 
       - name: Set up gotestfmt
         uses: gotesttools/gotestfmt-action@v2


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
CodeFlare operator was upgraded to Go 1.21, breaking current e2e PR check.
This PR patches e2e workflow to setup Go version based on CodeFlare operator go.mod file.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
PR check should pass.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->