### PR TITLE
Simplify yaml generation by starting from non-AppWrapper template

### DIFF
--- a/src/codeflare_sdk/cluster/awload.py
+++ b/src/codeflare_sdk/cluster/awload.py
@@ -30,7 +30,7 @@ from .auth import config_check, api_config_handler
 class AWManager:
     """
     An object for submitting and removing existing AppWrapper yamls
-    to be added to the MCAD queue.
+    to be added to the Kueue localqueue.
     """
 
     def __init__(self, filename: str) -> None:

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -147,11 +147,9 @@ class Cluster:
         template = self.config.template
         image = self.config.image
         appwrapper = self.config.appwrapper
-        instance_types = self.config.machine_types
         env = self.config.envs
         image_pull_secrets = self.config.image_pull_secrets
         write_to_file = self.config.write_to_file
-        verify_tls = self.config.verify_tls
         local_queue = self.config.local_queue
         labels = self.config.labels
         return generate_appwrapper(
@@ -169,11 +167,9 @@ class Cluster:
             template=template,
             image=image,
             appwrapper=appwrapper,
-            instance_types=instance_types,
             env=env,
             image_pull_secrets=image_pull_secrets,
             write_to_file=write_to_file,
-            verify_tls=verify_tls,
             local_queue=local_queue,
             labels=labels,
         )
@@ -181,8 +177,8 @@ class Cluster:
     # creates a new cluster with the provided or default spec
     def up(self):
         """
-        Applies the AppWrapper yaml, pushing the resource request onto
-        the MCAD queue.
+        Applies the Cluster yaml, pushing the resource request onto
+        the Kueue localqueue.
         """
 
         # check if RayCluster CustomResourceDefinition exists if not throw RuntimeError

--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -1,207 +1,198 @@
-apiVersion: workload.codeflare.dev/v1beta2
-kind: AppWrapper
+# This config demonstrates KubeRay's Ray autoscaler integration.
+# The resource requests and limits in this config are too small for production!
+# For an example with more realistic resource configuration, see
+# ray-cluster.autoscaler.large.yaml.
+apiVersion: ray.io/v1
+kind: RayCluster
 metadata:
-  name: aw-kuberay
+  labels:
+    controller-tools.k8s.io: "1.0"
+    # A unique identifier for the head node and workers of this cluster.
+  name: kuberay-cluster
   namespace: default
 spec:
-  components:
-  - template:
-      # This config demonstrates KubeRay's Ray autoscaler integration.
-      # The resource requests and limits in this config are too small for production!
-      # For an example with more realistic resource configuration, see
-      # ray-cluster.autoscaler.large.yaml.
-      apiVersion: ray.io/v1
-      kind: RayCluster
+  # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
+  rayVersion: '2.7.0'
+  # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
+  # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
+  # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
+  enableInTreeAutoscaling: false
+  # autoscalerOptions is an OPTIONAL field specifying configuration overrides for the Ray autoscaler.
+  # The example configuration shown below below represents the DEFAULT values.
+  # (You may delete autoscalerOptions if the defaults are suitable.)
+  autoscalerOptions:
+    # upscalingMode is "Default" or "Aggressive."
+    # Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.
+    # Default: Upscaling is not rate-limited.
+    # Aggressive: An alias for Default; upscaling is not rate-limited.
+    upscalingMode: Default
+    # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
+    idleTimeoutSeconds: 60
+    # image optionally overrides the autoscaler's container image.
+    # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
+    # the ray container. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
+    ## image: "my-repo/my-custom-autoscaler-image:tag"
+    # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
+    imagePullPolicy: Always
+    # resources specifies optional resource request and limit overrides for the autoscaler container.
+    # For large Ray clusters, we recommend monitoring container resource usage to determine if overriding the defaults is required.
+    resources:
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+      requests:
+        cpu: "500m"
+        memory: "512Mi"
+  ######################headGroupSpec#################################
+  # head group template and specs, (perhaps 'group' is not needed in the name)
+  headGroupSpec:
+    # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
+    serviceType: ClusterIP
+    enableIngress: false
+    # logical group name, for this called head-group, also can be functional
+    # pod type head or worker
+    # rayNodeType: head # Not needed since it is under the headgroup
+    # the following params are used to complete the ray start: ray start --head --block ...
+    rayStartParams:
+      # Flag "no-monitor" will be automatically set when autoscaling is enabled.
+      dashboard-host: '0.0.0.0'
+      block: 'true'
+      # num-cpus: '1' # can be auto-completed from the limits
+      # Use `resources` to optionally specify custom resource annotations for the Ray node.
+      # The value of `resources` is a string-integer mapping.
+      # Currently, `resources` must be provided in the specific format demonstrated below:
+      # resources: '"{\"Custom1\": 1, \"Custom2\": 5}"'
+      num-gpus: '0'
+    #pod template
+    template:
+      spec:
+        containers:
+        # The Ray head pod
+        - name: ray-head
+          image: quay.io/project-codeflare/ray:latest-py39-cu118
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
+          resources:
+            limits:
+              cpu: 2
+              memory: "8G"
+              nvidia.com/gpu: 0
+            requests:
+              cpu: 2
+              memory: "8G"
+              nvidia.com/gpu: 0
+          volumeMounts:
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+        volumes:
+        - name: odh-trusted-ca-cert
+          configMap:
+            name: odh-trusted-ca-bundle
+            items:
+            - key: ca-bundle.crt
+              path: odh-trusted-ca-bundle.crt
+            optional: true
+        - name: odh-ca-cert
+          configMap:
+            name: odh-trusted-ca-bundle
+            items:
+            - key: odh-ca-bundle.crt
+              path: odh-ca-bundle.crt
+            optional: true
+  workerGroupSpecs:
+  # the pod replicas in this group typed worker
+  - replicas: 3
+    minReplicas: 3
+    maxReplicas: 3
+    # logical group name, for this called small-group, also can be functional
+    groupName: small-group
+    # if worker pods need to be added, we can simply increment the replicas
+    # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
+    # the operator will remove pods from the list until the number of replicas is satisfied
+    # when a pod is confirmed to be deleted, its name will be removed from the list below
+    #scaleStrategy:
+    #  workersToDelete:
+    #  - raycluster-complete-worker-small-group-bdtwh
+    #  - raycluster-complete-worker-small-group-hv457
+    #  - raycluster-complete-worker-small-group-k8tj7
+    # the following params are used to complete the ray start: ray start --block ...
+    rayStartParams:
+      block: 'true'
+      num-gpus: 1
+    #pod template
+    template:
       metadata:
         labels:
-          controller-tools.k8s.io: "1.0"
-          # A unique identifier for the head node and workers of this cluster.
-        name: kuberay-cluster
+          key: value
+        # annotations for pod
+        annotations:
+          key: value
         # finalizers:
         # - kubernetes
       spec:
-        # The version of Ray you are using. Make sure all Ray containers are running this version of Ray.
-        rayVersion: '2.7.0'
-        # If enableInTreeAutoscaling is true, the autoscaler sidecar will be added to the Ray head pod.
-        # Ray autoscaler integration is supported only for Ray versions >= 1.11.0
-        # Ray autoscaler integration is Beta with KubeRay >= 0.3.0 and Ray >= 2.0.0.
-        enableInTreeAutoscaling: false
-        # autoscalerOptions is an OPTIONAL field specifying configuration overrides for the Ray autoscaler.
-        # The example configuration shown below below represents the DEFAULT values.
-        # (You may delete autoscalerOptions if the defaults are suitable.)
-        autoscalerOptions:
-          # upscalingMode is "Default" or "Aggressive."
-          # Conservative: Upscaling is rate-limited; the number of pending worker pods is at most the size of the Ray cluster.
-          # Default: Upscaling is not rate-limited.
-          # Aggressive: An alias for Default; upscaling is not rate-limited.
-          upscalingMode: Default
-          # idleTimeoutSeconds is the number of seconds to wait before scaling down a worker pod which is not using Ray resources.
-          idleTimeoutSeconds: 60
-          # image optionally overrides the autoscaler's container image.
-          # If instance.spec.rayVersion is at least "2.0.0", the autoscaler will default to the same image as
-          # the ray container. For older Ray versions, the autoscaler will default to using the Ray 2.0.0 image.
-          ## image: "my-repo/my-custom-autoscaler-image:tag"
-          # imagePullPolicy optionally overrides the autoscaler container's image pull policy.
-          imagePullPolicy: Always
-          # resources specifies optional resource request and limit overrides for the autoscaler container.
-          # For large Ray clusters, we recommend monitoring container resource usage to determine if overriding the defaults is required.
+        containers:
+        - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
+          image: quay.io/project-codeflare/ray:latest-py39-cu118
+          # environment variables to set in the container.Optional.
+          # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh","-c","ray stop"]
           resources:
             limits:
-              cpu: "500m"
-              memory: "512Mi"
+              cpu: "2"
+              memory: "12G"
+              nvidia.com/gpu: "1"
             requests:
-              cpu: "500m"
-              memory: "512Mi"
-        ######################headGroupSpec#################################
-        # head group template and specs, (perhaps 'group' is not needed in the name)
-        headGroupSpec:
-          # Kubernetes Service Type, valid values are 'ClusterIP', 'NodePort' and 'LoadBalancer'
-          serviceType: ClusterIP
-          enableIngress: false
-          # logical group name, for this called head-group, also can be functional
-          # pod type head or worker
-          # rayNodeType: head # Not needed since it is under the headgroup
-          # the following params are used to complete the ray start: ray start --head --block ...
-          rayStartParams:
-            # Flag "no-monitor" will be automatically set when autoscaling is enabled.
-            dashboard-host: '0.0.0.0'
-            block: 'true'
-            # num-cpus: '1' # can be auto-completed from the limits
-            # Use `resources` to optionally specify custom resource annotations for the Ray node.
-            # The value of `resources` is a string-integer mapping.
-            # Currently, `resources` must be provided in the specific format demonstrated below:
-            # resources: '"{\"Custom1\": 1, \"Custom2\": 5}"'
-            num-gpus: '0'
-          #pod template
-          template:
-            spec:
-              containers:
-              # The Ray head pod
-              - name: ray-head
-                image: quay.io/project-codeflare/ray:latest-py39-cu118
-                imagePullPolicy: Always
-                ports:
-                - containerPort: 6379
-                  name: gcs
-                - containerPort: 8265
-                  name: dashboard
-                - containerPort: 10001
-                  name: client
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
-                resources:
-                  limits:
-                    cpu: 2
-                    memory: "8G"
-                    nvidia.com/gpu: 0
-                  requests:
-                    cpu: 2
-                    memory: "8G"
-                    nvidia.com/gpu: 0
-                volumeMounts:
-                - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
-                  name: odh-trusted-ca-cert
-                  subPath: odh-trusted-ca-bundle.crt
-                - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
-                  name: odh-trusted-ca-cert
-                  subPath: odh-trusted-ca-bundle.crt
-                - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
-                  name: odh-ca-cert
-                  subPath: odh-ca-bundle.crt
-                - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
-                  name: odh-ca-cert
-                  subPath: odh-ca-bundle.crt
-              volumes:
-              - name: odh-trusted-ca-cert
-                configMap:
-                  name: odh-trusted-ca-bundle
-                  items:
-                  - key: ca-bundle.crt
-                    path: odh-trusted-ca-bundle.crt
-                  optional: true
-              - name: odh-ca-cert
-                configMap:
-                  name: odh-trusted-ca-bundle
-                  items:
-                  - key: odh-ca-bundle.crt
-                    path: odh-ca-bundle.crt
-                  optional: true
-        workerGroupSpecs:
-        # the pod replicas in this group typed worker
-        - replicas: 3
-          minReplicas: 3
-          maxReplicas: 3
-          # logical group name, for this called small-group, also can be functional
-          groupName: small-group
-          # if worker pods need to be added, we can simply increment the replicas
-          # if worker pods need to be removed, we decrement the replicas, and populate the podsToDelete list
-          # the operator will remove pods from the list until the number of replicas is satisfied
-          # when a pod is confirmed to be deleted, its name will be removed from the list below
-          #scaleStrategy:
-          #  workersToDelete:
-          #  - raycluster-complete-worker-small-group-bdtwh
-          #  - raycluster-complete-worker-small-group-hv457
-          #  - raycluster-complete-worker-small-group-k8tj7
-          # the following params are used to complete the ray start: ray start --block ...
-          rayStartParams:
-            block: 'true'
-            num-gpus: 1
-          #pod template
-          template:
-            metadata:
-              labels:
-                key: value
-              # annotations for pod
-              annotations:
-                key: value
-              # finalizers:
-              # - kubernetes
-            spec:
-              containers:
-              - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-                image: quay.io/project-codeflare/ray:latest-py39-cu118
-                # environment variables to set in the container.Optional.
-                # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-                lifecycle:
-                  preStop:
-                    exec:
-                      command: ["/bin/sh","-c","ray stop"]
-                resources:
-                  limits:
-                    cpu: "2"
-                    memory: "12G"
-                    nvidia.com/gpu: "1"
-                  requests:
-                    cpu: "2"
-                    memory: "12G"
-                    nvidia.com/gpu: "1"
-                volumeMounts:
-                - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
-                  name: odh-trusted-ca-cert
-                  subPath: odh-trusted-ca-bundle.crt
-                - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
-                  name: odh-trusted-ca-cert
-                  subPath: odh-trusted-ca-bundle.crt
-                - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
-                  name: odh-ca-cert
-                  subPath: odh-ca-bundle.crt
-                - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
-                  name: odh-ca-cert
-                  subPath: odh-ca-bundle.crt
-              volumes:
-              - name: odh-trusted-ca-cert
-                configMap:
-                  name: odh-trusted-ca-bundle
-                  items:
-                  - key: ca-bundle.crt
-                    path: odh-trusted-ca-bundle.crt
-                  optional: true
-              - name: odh-ca-cert
-                configMap:
-                  name: odh-trusted-ca-bundle
-                  items:
-                  - key: odh-ca-bundle.crt
-                    path: odh-ca-bundle.crt
-                  optional: true
+              cpu: "2"
+              memory: "12G"
+              nvidia.com/gpu: "1"
+          volumeMounts:
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+        volumes:
+        - name: odh-trusted-ca-cert
+          configMap:
+            name: odh-trusted-ca-bundle
+            items:
+            - key: ca-bundle.crt
+              path: odh-trusted-ca-bundle.crt
+            optional: true
+        - name: odh-ca-cert
+          configMap:
+            name: odh-trusted-ca-bundle
+            items:
+            - key: odh-ca-bundle.crt
+              path: odh-ca-bundle.crt
+            optional: true

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -1,4 +1,3 @@
----
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -73,8 +73,6 @@ import codeflare_sdk.utils.kube_api_helpers
 from codeflare_sdk.utils.generate_yaml import (
     gen_names,
     is_openshift_cluster,
-    read_template,
-    write_components,
 )
 
 import openshift


### PR DESCRIPTION
The v1/beta2 AppWrapper can be wrapped around a RayCluster as a simple prefix to the "real" yaml.  So we can simplify yaml generation/manipulation by starting with a vanilla RayCluster and just optionally put it inside an AppWrapper at the end.
