### PR TITLE
Add notebook annotation to RayCluster

### DIFF
--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -246,6 +246,17 @@ def augment_labels(item: dict, labels: dict):
     item["template"]["metadata"]["labels"].update(labels)
 
 
+def notebook_annotations(item: dict):
+    nb_prefix = os.environ.get("NB_PREFIX")
+    if nb_prefix:
+        if "template" in item:
+            if not "annotations" in item["template"]["metadata"]:
+                item["template"]["metadata"]["annotations"] = {}
+        item["template"]["metadata"]["annotations"].update(
+            {"app.kubernetes.io/managed-by": nb_prefix}
+        )
+
+
 def write_components(
     user_yaml: dict,
     output_file_name: str,
@@ -341,6 +352,7 @@ def generate_appwrapper(
     )
 
     augment_labels(item, labels)
+    notebook_annotations(item)
 
     if appwrapper:
         add_queue_label(user_yaml, namespace, local_queue)

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -2,6 +2,8 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
+  annotations:
+    app.kubernetes.io/managed-by: test-prefix
   labels:
     controller-tools.k8s.io: '1.0'
     kueue.x-k8s.io/queue-name: local-queue-default

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -345,6 +345,8 @@ def test_cluster_creation_no_mcad(mocker):
         "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
         return_value=get_local_queue("kueue.x-k8s.io", "v1beta1", "ns", "localqueues"),
     )
+    mocker.patch("os.environ.get", return_value="test-prefix")
+
     config = createClusterConfig()
     config.name = "unit-test-cluster-ray"
     config.write_to_file = True
@@ -373,6 +375,7 @@ def test_cluster_creation_no_mcad_local_queue(mocker):
         "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
         return_value=get_local_queue("kueue.x-k8s.io", "v1beta1", "ns", "localqueues"),
     )
+    mocker.patch("os.environ.get", return_value="test-prefix")
     config = createClusterConfig()
     config.name = "unit-test-cluster-ray"
     config.appwrapper = False


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[https://issues.redhat.com/browse/RHOAIENG-6301](https://issues.redhat.com/browse/RHOAIENG-6301)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added the notebook prefix annotation to RayCluster when it was created from the workbench. That should allow to construct a workbench url for the metrics

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Create a RayCluster from the Data Science Projects Workbench, the created cluster should have an annotation `app.kubernetes.io/managed-by:`

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->