### PR TITLE
Update Token Authentication for TestMnistJobSubmit before step get_cluster 

### DIFF
--- a/tests/upgrade/raycluster_sdk_upgrade_test.py
+++ b/tests/upgrade/raycluster_sdk_upgrade_test.py
@@ -82,19 +82,18 @@ class TestMNISTRayClusterUp:
 class TestMnistJobSubmit:
     def setup_method(self):
         initialize_kubernetes_client(self)
-        self.namespace = namespace
-        self.cluster = get_cluster("mnist", self.namespace)
-        if not self.cluster:
-            raise RuntimeError("TestRayClusterUp needs to be run before this test")
-
-    def test_mnist_job_submission(self):
         auth = TokenAuthentication(
             token=run_oc_command(["whoami", "--show-token=true"]),
             server=run_oc_command(["whoami", "--show-server=true"]),
             skip_tls=True,
         )
         auth.login()
+        self.namespace = namespace
+        self.cluster = get_cluster("mnist", self.namespace)
+        if not self.cluster:
+            raise RuntimeError("TestRayClusterUp needs to be run before this test")
 
+    def test_mnist_job_submission(self):
         self.assert_jobsubmit_withoutLogin(self.cluster)
         self.assert_jobsubmit_withlogin(self.cluster)
 


### PR DESCRIPTION


# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
https://issues.redhat.com/browse/RHOAIENG-7032 
While running in CI test `TestMnistJobSubmit` failing due to authentication and default kube config not in default location
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
updated Token Authentication step before calling get_cluster function for TestMnistJobSubmit
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->