### PR TITLE
Add arguments to pass Ray cluster head and worker templates

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1274,6 +1274,17 @@ lint = ["black", "check-manifest", "flake8", "isort", "mypy"]
 test = ["Cython", "greenlet", "ipython", "pytest", "pytest-cov", "setuptools"]
 
 [[package]]
+name = "mergedeep"
+version = "1.3.4"
+description = "A deep merge function for 🐍."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
 name = "msgpack"
 version = "1.0.8"
 description = "MessagePack serializer"
@@ -2795,4 +2806,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "d656bab99c2e5a911ee1003db9e0682141328ae3ef1e1620945f8479451425bf"
+content-hash = "641a3685dcb9a044e49d903bdb0d8911d410f7a65e7835dda087a194c47e3c64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ cryptography = "40.0.2"
 executing = "1.2.0"
 pydantic = "< 2"
 ipywidgets = "8.1.2"
+mergedeep = "1.3.4"
 
 [tool.poetry.group.docs]
 optional = true

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -18,11 +18,9 @@ the resources requested by the user. It also contains functions for checking the
 cluster setup queue, a list of all existing clusters, and the user's working namespace.
 """
 
-import re
 from time import sleep
 from typing import List, Optional, Tuple, Dict
 
-from kubernetes import config
 from ray.job_submission import JobSubmissionClient
 
 from .auth import config_check, api_config_handler
@@ -41,13 +39,11 @@ from .model import (
     RayCluster,
     RayClusterStatus,
 )
-from kubernetes import client, config
-from kubernetes.utils import parse_quantity
 import yaml
 import os
 import requests
 
-from kubernetes import config
+from kubernetes import client, config
 from kubernetes.client.rest import ApiException
 
 
@@ -145,6 +141,8 @@ class Cluster:
         gpu = self.config.num_gpus
         workers = self.config.num_workers
         template = self.config.template
+        head_template = self.config.head_template
+        worker_template = self.config.worker_template
         image = self.config.image
         appwrapper = self.config.appwrapper
         env = self.config.envs
@@ -167,6 +165,8 @@ class Cluster:
             gpu=gpu,
             workers=workers,
             template=template,
+            head_template=head_template,
+            worker_template=worker_template,
             image=image,
             appwrapper=appwrapper,
             env=env,

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -22,6 +22,8 @@ from dataclasses import dataclass, field
 import pathlib
 import typing
 
+import kubernetes
+
 dir = pathlib.Path(__file__).parent.parent.resolve()
 
 
@@ -46,6 +48,8 @@ class ClusterConfiguration:
     max_memory: typing.Union[int, str] = 2
     num_gpus: int = 0
     template: str = f"{dir}/templates/base-template.yaml"
+    head_template: kubernetes.client.V1PodTemplateSpec = None
+    worker_template: kubernetes.client.V1PodTemplateSpec = None
     appwrapper: bool = False
     envs: dict = field(default_factory=dict)
     image: str = ""


### PR DESCRIPTION
# Issue link

Fixes #413.

# What changes have been made

This PR adds parameters to the Ray cluster configuration API, so users can provide Pod template for the head and worker nodes, e.g.:

```python
from kubernetes import V1PodTemplateSpec, V1PodSpec, V1Toleration

cluster = Cluster(ClusterConfiguration(
    worker_template=V1PodTemplateSpec(
        spec=V1PodSpec(
            tolerations=[V1Toleration(
                key="nvidia.com/gpu",
                operator="Exists",
                effect="NoSchedule",
            )],
            node_selector={
                "nvidia.com/gpu.present": "true",
            },
        )
    ),
    head_template=V1PodTemplateSpec(...),
))
```

# Verification steps

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change