### PR TITLE
Make Local Queue label optional

### DIFF
--- a/tests/test-case-no-kueue-no-aw.yaml
+++ b/tests/test-case-no-kueue-no-aw.yaml
@@ -1,0 +1,153 @@
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  annotations:
+    app.kubernetes.io/managed-by: test-prefix
+  labels:
+    controller-tools.k8s.io: '1.0'
+  name: unit-test-no-kueue
+  namespace: ns
+spec:
+  autoscalerOptions:
+    idleTimeoutSeconds: 60
+    imagePullPolicy: Always
+    resources:
+      limits:
+        cpu: 500m
+        memory: 512Mi
+      requests:
+        cpu: 500m
+        memory: 512Mi
+    upscalingMode: Default
+  enableInTreeAutoscaling: false
+  headGroupSpec:
+    enableIngress: false
+    rayStartParams:
+      block: 'true'
+      dashboard-host: 0.0.0.0
+      num-gpus: '0'
+    serviceType: ClusterIP
+    template:
+      spec:
+        containers:
+        - image: quay.io/rhoai/ray:2.23.0-py39-cu121
+          imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - ray stop
+          name: ray-head
+          ports:
+          - containerPort: 6379
+            name: gcs
+          - containerPort: 8265
+            name: dashboard
+          - containerPort: 10001
+            name: client
+          resources:
+            limits:
+              cpu: 2
+              memory: 8G
+              nvidia.com/gpu: 0
+            requests:
+              cpu: 2
+              memory: 8G
+              nvidia.com/gpu: 0
+          volumeMounts:
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+        imagePullSecrets:
+        - name: unit-test-pull-secret
+        volumes:
+        - configMap:
+            items:
+            - key: ca-bundle.crt
+              path: odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-trusted-ca-cert
+        - configMap:
+            items:
+            - key: odh-ca-bundle.crt
+              path: odh-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-ca-cert
+  rayVersion: 2.23.0
+  workerGroupSpecs:
+  - groupName: small-group-unit-test-no-kueue
+    maxReplicas: 2
+    minReplicas: 2
+    rayStartParams:
+      block: 'true'
+      num-gpus: '7'
+    replicas: 2
+    template:
+      metadata:
+        annotations:
+          key: value
+        labels:
+          key: value
+      spec:
+        containers:
+        - image: quay.io/rhoai/ray:2.23.0-py39-cu121
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - ray stop
+          name: machine-learning
+          resources:
+            limits:
+              cpu: 4
+              memory: 6G
+              nvidia.com/gpu: 7
+            requests:
+              cpu: 3
+              memory: 5G
+              nvidia.com/gpu: 7
+          volumeMounts:
+          - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-cert
+            subPath: odh-trusted-ca-bundle.crt
+          - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+          - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+            name: odh-ca-cert
+            subPath: odh-ca-bundle.crt
+        imagePullSecrets:
+        - name: unit-test-pull-secret
+        volumes:
+        - configMap:
+            items:
+            - key: ca-bundle.crt
+              path: odh-trusted-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-trusted-ca-cert
+        - configMap:
+            items:
+            - key: odh-ca-bundle.crt
+              path: odh-ca-bundle.crt
+            name: odh-trusted-ca-bundle
+            optional: true
+          name: odh-ca-cert


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
closes: [RHOAIENG-9348](https://issues.redhat.com/browse/RHOAIENG-9348)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Altered the local_queue functionality so if no default local queue exists or `local_queue` is not specified then the label will not be applied to the Ray Cluster.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
### Remove Kueue from your OpenShift Cluster
* In the RHOAI DSC set Kueue's management state to `Removed`
* Create a Ray Cluster in the `ClusterConfiguration` without a local queue specified.
* Ensure the Ray Cluster does not have a local queue label
### Kueue is enabled but no default Local Queue exists
* Ensure no default Local Queue exists in a given namespace
* Create a Ray Cluster without the local queue specified
* Ensure the created Ray Cluster does not have the local queue label.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->