### PR TITLE
Updated image parameter to be optional

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -103,16 +103,6 @@ class Cluster:
             )
         return self._job_submission_client
 
-    def validate_image_config(self):
-        """
-        Validates that the image configuration is not empty.
-
-        :param image: The image string to validate
-        :raises ValueError: If the image is not specified
-        """
-        if self.config.image == "" or self.config.image == None:
-            raise ValueError("Image must be specified in the ClusterConfiguration")
-
     def create_app_wrapper(self):
         """
         Called upon cluster object creation, creates an AppWrapper yaml based on
@@ -127,9 +117,6 @@ class Cluster:
                 raise TypeError(
                     f"Namespace {self.config.namespace} is of type {type(self.config.namespace)}. Check your Kubernetes Authentication."
                 )
-
-        # Validate image configuration
-        self.validate_image_config()
 
         # Before attempting to create the cluster AW, let's evaluate the ClusterConfig
 

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -86,8 +86,9 @@ def update_names(cluster_yaml, cluster_name, namespace):
 
 def update_image(spec, image):
     containers = spec.get("containers")
-    for container in containers:
-        container["image"] = image
+    if image != "":
+        for container in containers:
+            container["image"] = image
 
 
 def update_image_pull_secrets(spec, image_pull_secrets):

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -307,19 +307,6 @@ def test_cluster_no_kueue_no_aw(mocker):
     )
 
 
-def test_create_app_wrapper_raises_error_with_no_image():
-    config = createClusterConfig()
-    config.image = ""  # Clear the image to test error handling
-    try:
-        cluster = Cluster(config)
-        cluster.create_app_wrapper()
-        assert False, "Expected ValueError when 'image' is not specified."
-    except ValueError as error:
-        assert (
-            str(error) == "Image must be specified in the ClusterConfiguration"
-        ), "Error message did not match expected output."
-
-
 def get_local_queue(group, version, namespace, plural):
     assert group == "kueue.x-k8s.io"
     assert version == "v1beta1"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes: [RHOAIENG-9504](https://issues.redhat.com/browse/RHOAIENG-9504)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Removed the validation function for the image parameter of the `ClusterConfiguration` 
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
### Test no image
Create a Ray Cluster while omitting `image` from the `ClusterConfiguration`. 
The Ray Cluster's image should be `quay.io/rhoai/ray:2.23.0-py39-cu121`
### Test with image
Create a Ray Cluster with the image parameter equating to any Ray compatible image e.g. `quay.io/project-codeflare/ray:latest-py39-cu118`
The Ray Cluster's image should be the image you set as the image parameter.
## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->