### PR TITLE
Add Type validation for Cluster Configuration Parameters

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -67,6 +67,7 @@ from codeflare_sdk.utils.generate_cert import (
 from tests.unit_test_support import (
     createClusterWithConfig,
     createClusterConfig,
+    createClusterWrongType,
 )
 
 import codeflare_sdk.utils.kube_api_helpers
@@ -266,6 +267,11 @@ def test_config_creation():
     assert config.machine_types == ["cpu.small", "gpu.large"]
     assert config.image_pull_secrets == ["unit-test-pull-secret"]
     assert config.appwrapper == True
+
+
+def test_config_creation_wrong_type():
+    with pytest.raises(TypeError):
+        config = createClusterWrongType()
 
 
 def test_cluster_creation(mocker):

--- a/tests/unit_test_support.py
+++ b/tests/unit_test_support.py
@@ -31,3 +31,23 @@ def createClusterWithConfig(mocker):
     )
     cluster = Cluster(createClusterConfig())
     return cluster
+
+
+def createClusterWrongType():
+    config = ClusterConfiguration(
+        name="unit-test-cluster",
+        namespace="ns",
+        num_workers=2,
+        worker_cpu_requests=[],
+        worker_cpu_limits=4,
+        worker_memory_requests=5,
+        worker_memory_limits=6,
+        worker_extended_resource_requests={"nvidia.com/gpu": 7},
+        appwrapper=True,
+        machine_types=[True, False],
+        image_pull_secrets=["unit-test-pull-secret"],
+        image="quay.io/rhoai/ray:2.23.0-py39-cu121",
+        write_to_file=True,
+        labels={1: 1},
+    )
+    return config


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[https://issues.redhat.com/browse/RHOAIENG-9435](https://issues.redhat.com/browse/RHOAIENG-9435)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added Type Validation for Parameters
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
In Cluster Configuration change any of the parameters to a wrong type. Should get an error similar to this:
`'num_workers' should be of type <class 'int'>, got list`


## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->