### PR TITLE
Make ray image parameter as optional

### DIFF
--- a/docs/cluster-configuration.md
+++ b/docs/cluster-configuration.md
@@ -19,11 +19,12 @@ cluster = Cluster(ClusterConfiguration(
     min_memory=2, # Default 2
     max_memory=2, # Default 2
     num_gpus=0, # Default 0
-    image="quay.io/rhoai/ray:2.23.0-py39-cu121", # Mandatory Field
+    # image="", # Optional Field
     machine_types=["m5.xlarge", "g4dn.xlarge"],
     labels={"exampleLabel": "example", "secondLabel": "example"},
 ))
 ```
+Note: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. If you have your own Ray image which suits your purposes, specify it in image field to override the default image.
 
 The `labels={"exampleLabel": "example"}` parameter can be used to apply additional labels to the RayCluster resource.
 

--- a/src/codeflare_sdk/demo-notebooks/additional-demos/hf_interactive.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/additional-demos/hf_interactive.ipynb
@@ -68,8 +68,8 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding Ray Cluster).\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -98,7 +98,7 @@
     "                                       max_cpus=8, \n",
     "                                       min_memory=16, \n",
     "                                       max_memory=16, \n",
-    "                                       image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "                                       # image=\"\", # Optional Field \n",
     "                                       write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "                                       # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "                                       ))"

--- a/src/codeflare_sdk/demo-notebooks/additional-demos/local_interactive.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/additional-demos/local_interactive.ipynb
@@ -35,8 +35,8 @@
    "metadata": {},
    "source": [
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -61,7 +61,7 @@
     "                                       max_cpus=1,\n",
     "                                       min_memory=4,\n",
     "                                       max_memory=4,\n",
-    "                                       image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "                                       # image=\"\", # Optional Field \n",
     "                                       write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "                                       # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "                                       ))"

--- a/src/codeflare_sdk/demo-notebooks/additional-demos/ray_job_client.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/additional-demos/ray_job_client.ipynb
@@ -36,6 +36,16 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "id": "18de2d65",
+    "metadata": {},
+    "source": [
+     "\n",
+     "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+     "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    ]
+   },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -52,8 +62,9 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
+    "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"
    ]
   },

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/0_basic_ray.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/0_basic_ray.ipynb
@@ -47,8 +47,8 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -71,7 +71,7 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
@@ -35,6 +35,17 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "id": "bc27f84c",
+    "metadata": {},
+    "source": [
+     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
+     "\n",
+     "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+     "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    ]
+   },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -53,7 +64,7 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/2_basic_interactive.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/2_basic_interactive.ipynb
@@ -44,8 +44,8 @@
    "source": [
     "Once again, let's start by running through the same cluster setup as before:\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -65,11 +65,11 @@
     "    head_gpus=1, # For GPU enabled workloads set the head_gpus and num_gpus\n",
     "    num_gpus=1,\n",
     "    num_workers=2,\n",
-    "    min_cpus='250m',\n",
-    "    max_cpus=1,\n",
-    "    min_memory=4,\n",
-    "    max_memory=6,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    min_cpus=2,\n",
+    "    max_cpus=2,\n",
+    "    min_memory=8,\n",
+    "    max_memory=8,\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
@@ -47,8 +47,8 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -77,7 +77,7 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
@@ -35,6 +35,17 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "id": "bc27f84c",
+    "metadata": {},
+    "source": [
+     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
+     "\n",
+     "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+     "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    ]
+   },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -51,7 +62,7 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
@@ -44,8 +44,8 @@
    "source": [
     "Once again, let's start by running through the same cluster setup as before:\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -75,7 +75,7 @@
     "    max_cpus=2,\n",
     "    min_memory=8,\n",
     "    max_memory=8,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
@@ -47,8 +47,8 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -69,7 +69,7 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
@@ -35,6 +35,17 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "id": "bc27f84c",
+    "metadata": {},
+    "source": [
+     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
+     "\n",
+     "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+     "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    ]
+   },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -51,7 +62,7 @@
     "    max_cpus=1,\n",
     "    min_memory=4,\n",
     "    max_memory=4,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources\n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"

--- a/src/codeflare_sdk/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
+++ b/src/codeflare_sdk/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
@@ -44,8 +44,8 @@
    "source": [
     "Once again, let's start by running through the same cluster setup as before:\n",
     "\n",
-    "NOTE: We must specify the `image` which will be used in our RayCluster, we recommend you bring your own image which suits your purposes. \n",
-    "The example here is a community image."
+    "NOTE: 'quay.io/rhoai/ray:2.23.0-py39-cu121' is the default community image used by the CodeFlare SDK for creating a RayCluster resource. \n",
+    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
    ]
   },
   {
@@ -67,7 +67,7 @@
     "    max_cpus=2,\n",
     "    min_memory=8,\n",
     "    max_memory=8,\n",
-    "    image=\"quay.io/rhoai/ray:2.23.0-py39-cu121\",\n",
+    "    # image=\"\", # Optional Field \n",
     "    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources \n",
     "    # local_queue=\"local-queue-name\" # Specify the local queue manually\n",
     "))"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-10006 


# What changes have been made
With the new UBI9 based ray runtime image `quay.io/rhoai/ray:2.23.0-py39-cu121` used as default in codeflare-sdk raycluster-configuration, updating references of image parameter as optional in

- ClusterConfiguration docs
- demo-notebooks

# Verification steps

1. Clone the repository with git clone https://github.com/ChughShilpa/codeflare-sdk
2. Checkout this PR's branch "image_parameter"
3. Run any demo-notebooks


## Checks
- [X] I've made sure the tests are passing. 
- Testing Strategy
   - [X] Unit tests
   - [X] Manual tests
   - [ ] Testing is not required for this change

