### PR TITLE
add: Functionality to generate a ClusterConfiguration Template in the next notebook cell

### DIFF
--- a/src/codeflare_sdk/__init__.py
+++ b/src/codeflare_sdk/__init__.py
@@ -18,7 +18,7 @@ from .cluster import (
 
 from .job import RayJobClient
 
-from .utils import generate_cert
+from .utils import generate_cert, generateClusterConfig
 from .utils.demos import copy_demo_nbs
 
 from importlib.metadata import version, PackageNotFoundError

--- a/src/codeflare_sdk/utils/__init__.py
+++ b/src/codeflare_sdk/utils/__init__.py
@@ -1,0 +1,1 @@
+from .generate_config import generateClusterConfig

--- a/src/codeflare_sdk/utils/generate_config.py
+++ b/src/codeflare_sdk/utils/generate_config.py
@@ -1,0 +1,26 @@
+from IPython.display import display, Markdown
+from IPython import get_ipython
+
+
+def generateClusterConfig():
+    """
+    Generate a ClusterConfiguration template and insert it into a new cell in the Jupyter notebook.
+    """
+    config_code = """cluster = Cluster(ClusterConfiguration(
+    name='',
+    head_cpus='',
+    head_memory='',
+    head_gpus='', # For GPU enabled workloads set the head_gpus and num_gpus
+    num_gpus='',
+    num_workers='',
+    min_cpus='',
+    max_cpus='',
+    min_memory='',
+    max_memory='',
+    image="", # Optional Field
+    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources
+    local_queue="" # Specify the local queue manually
+))"""
+
+    # Add the generated ClusterConfiguration template into the next cell
+    get_ipython().set_next_input(config_code)


### PR DESCRIPTION
# Issue link


# What changes have been made
This PR adds a new util function, generateClusterConfig. 

The function will simplify the process of setting up a cluster by providing an unfilled ClusterConfiguration in the following cell.

# Verification steps
- Build the sdk
- Open a new Notebook and install the sdk
- Import the generateClusterConfig function: 
```
from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication, generateClusterConfig
```

- Now, running `generateClusterConfig()` will add a new cell in the notebook with a ClusterConfiguration template:
```
cluster = Cluster(ClusterConfiguration(
    name='',
    head_cpus='',
    head_memory='',
    head_gpus='', # For GPU enabled workloads set the head_gpus and num_gpus
    num_gpus='',
    num_workers='',
    min_cpus='',
    max_cpus='',
    min_memory='',
    max_memory='',
    image="", # Optional Field
    write_to_file=False, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources
    local_queue="" # Specify the local queue manually
))
```

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->