### PR TITLE
Update s3 bucket endpoint url to remove https prefix

### DIFF
--- a/tests/e2e/mnist.py
+++ b/tests/e2e/mnist.py
@@ -154,11 +154,19 @@ class LitMNIST(LightningModule):
             secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
             bucket_name = os.environ.get("AWS_STORAGE_BUCKET")
 
+            if endpoint.startswith("https://"):
+                endpoint = endpoint[len("https://") :]
+                secure = True
+            elif endpoint.startswith("http://"):
+                endpoint = endpoint[len("http://") :]
+                secure = False
+
             client = Minio(
                 endpoint,
                 access_key=access_key,
                 secret_key=secret_key,
                 cert_check=False,
+                secure=secure,
             )
 
             if not os.path.exists(dataset_dir):


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->


# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
When using the python Minio client to connect to a minio storage bucket, the endpoint URL should not include the `http://` ot `https://` prefix.

- While using https, set `secure=True`
- While using http as a protocol, set `secure=false`

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->