### PR TITLE
Remove Notebook Image Build and Push steps from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,23 +86,6 @@ jobs:
             - name: Publish package distributions to PyPI
               uses: pypa/gh-action-pypi-publish@release/v1
 
-            - name: Notebook Image Build and Push
-              run: |
-                gh workflow run image-build-and-push.yaml --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-sdk --ref ${{ github.ref }} --field is-stable=${{ github.event.inputs.is-stable }} --field release-version=${{ github.event.inputs.release-version }} --field quay-organization=${{ github.event.inputs.quay-organization }}
-              env:
-                GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
-              shell: bash
-
-            - name: Wait for Notebook image build and push to finish
-              run: |
-                # wait for a while for Run to be started
-                sleep 5
-                run_id=$(gh run list --workflow image-build-and-push.yaml --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-sdk --limit 1 --json databaseId --jq .[].databaseId)
-                gh run watch ${run_id} --repo ${{ github.event.inputs.codeflare-repository-organization }}/codeflare-sdk --interval 10 --exit-status
-              env:
-                GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}
-              shell: bash
-
             - name: Sync ODH Notebooks
               run: |
                 gh workflow run odh-notebooks-sync.yml \


### PR DESCRIPTION
# Issue link
Related to release of codeflare sdk. 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Removing Notebook Image Build and Push steps from the release workflow as they are no longer required.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->