### PR TITLE
[FIX] generate cert functionality

### DIFF
--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -2620,6 +2620,10 @@ def test_generate_tls_cert(mocker):
     """
     mocker.patch("kubernetes.config.load_kube_config", return_value="ignore")
     mocker.patch(
+        "codeflare_sdk.utils.generate_cert.get_secret_name",
+        return_value="ca-secret-cluster",
+    )
+    mocker.patch(
         "kubernetes.client.CoreV1Api.read_namespaced_secret",
         side_effect=secret_ca_retreival,
     )


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added function `get_secret_name` Which uses a label selector to gather the secret name for the given Ray Cluster.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
* Create a deployment of CodeFlare Operator from main 
* Run the basic interactive and local interactive demos 
* ensure that secrets are created when using `generate_cert()`
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->