### PR TITLE
ipywidgets UI create delete

### DIFF
--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -42,6 +42,10 @@ from .model import (
     RayCluster,
     RayClusterStatus,
 )
+from .widgets import (
+    cluster_up_down_buttons,
+    is_notebook,
+)
 from kubernetes import client, config
 from kubernetes.utils import parse_quantity
 import yaml
@@ -71,6 +75,8 @@ class Cluster:
         self.app_wrapper_yaml = self.create_app_wrapper()
         self._job_submission_client = None
         self.app_wrapper_name = self.config.name
+        if is_notebook():
+            cluster_up_down_buttons(self)
 
     @property
     def _client_headers(self):
@@ -156,8 +162,12 @@ class Cluster:
                         plural="appwrappers",
                         body=aw,
                     )
+                print(f"AppWrapper: '{self.config.name}' has successfully been created")
             else:
                 self._component_resources_up(namespace, api_instance)
+                print(
+                    f"Ray Cluster: '{self.config.name}' has successfully been created"
+                )
         except Exception as e:  # pragma: no cover
             return _kube_api_error_handling(e)
 
@@ -198,8 +208,12 @@ class Cluster:
                     plural="appwrappers",
                     name=self.app_wrapper_name,
                 )
+                print(f"AppWrapper: '{self.config.name}' has successfully been deleted")
             else:
                 self._component_resources_down(namespace, api_instance)
+                print(
+                    f"Ray Cluster: '{self.config.name}' has successfully been deleted"
+                )
         except Exception as e:  # pragma: no cover
             return _kube_api_error_handling(e)
 

--- a/src/codeflare_sdk/cluster/widgets.py
+++ b/src/codeflare_sdk/cluster/widgets.py
@@ -1,0 +1,91 @@
+# Copyright 2022 IBM, Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The widgets sub-module contains the ui widgets created using the ipywidgets package.
+"""
+import ipywidgets as widgets
+from IPython.display import display
+import os
+import codeflare_sdk
+
+
+def cluster_up_down_buttons(cluster: "codeflare_sdk.cluster.Cluster") -> widgets.Button:
+    """
+    The cluster_up_down_buttons function returns two button widgets for a create and delete button.
+    The function uses the appwrapper bool to distinguish between resource type for the tool tip.
+    """
+    resource = "Ray Cluster"
+    if cluster.config.appwrapper:
+        resource = "AppWrapper"
+
+    up_button = widgets.Button(
+        description="Cluster Up",
+        tooltip=f"Create the {resource}",
+        icon="play",
+    )
+
+    delete_button = widgets.Button(
+        description="Cluster Down",
+        tooltip=f"Delete the {resource}",
+        icon="trash",
+    )
+
+    wait_ready_check = wait_ready_check_box()
+    output = widgets.Output()
+
+    # Display the buttons in an HBox wrapped in a VBox which includes the wait_ready Checkbox
+    button_display = widgets.HBox([up_button, delete_button])
+    display(widgets.VBox([button_display, wait_ready_check]), output)
+
+    def on_up_button_clicked(b):  # Handle the up button click event
+        with output:
+            output.clear_output()
+            cluster.up()
+
+            # If the wait_ready Checkbox is clicked(value == True) trigger the wait_ready function
+            if wait_ready_check.value:
+                cluster.wait_ready()
+
+    def on_down_button_clicked(b):  # Handle the down button click event
+        with output:
+            output.clear_output()
+            cluster.down()
+
+    up_button.on_click(on_up_button_clicked)
+    delete_button.on_click(on_down_button_clicked)
+
+
+def wait_ready_check_box():
+    """
+    The wait_ready_check_box function will return a checkbox widget used for waiting for the resource to be in the state READY.
+    """
+    wait_ready_check_box = widgets.Checkbox(
+        False,
+        description="Wait for Cluster?",
+    )
+    return wait_ready_check_box
+
+
+def is_notebook() -> bool:
+    """
+    The is_notebook function checks if Jupyter Notebook environment variables exist in the given environment and return True/False based on that.
+    """
+    if (
+        "PYDEVD_IPYTHON_COMPATIBLE_DEBUGGING" in os.environ
+        or "JPY_SESSION_NAME" in os.environ
+    ):  # If running Jupyter NBs in VsCode or RHOAI/ODH display UI buttons
+        return True
+    else:
+        return False

--- a/src/codeflare_sdk/cluster/widgets.py
+++ b/src/codeflare_sdk/cluster/widgets.py
@@ -1,4 +1,4 @@
-# Copyright 2022 IBM, Red Hat
+# Copyright 2024 IBM, Red Hat
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -76,6 +76,7 @@ from codeflare_sdk.utils.generate_yaml import (
     gen_names,
     is_openshift_cluster,
 )
+from codeflare_sdk.cluster.widgets import cluster_up_down_buttons
 
 import openshift
 from openshift.selector import Selector


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes: [RHOAIENG-12523](https://issues.redhat.com/browse/RHOAIENG-12523)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
* Added ipywidgets to act as buttons for the `cluster.up()` and `cluster.down()` methods
* Added print statements to confirm cluster creation/deletion
* Added unit tests for buttons
* Added wait_ready Check Box

![image](https://github.com/user-attachments/assets/71197246-e077-4be8-a757-c2410aa8c27e)
Happy days :) 
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
* Run through any example notebook
* On the `ClusterConfiguration` step the ui buttons for cluster up/down should appear
* Verify the buttons work as expected
* Run the `ClusterConfiguration` as a script and the buttons should not appear.
* Run in a RHOAI notebook and in a VSCode local notebook and verify buttons are created

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->