### PR TITLE
wrap api client to add defaults

### DIFF
--- a/src/codeflare_sdk/cluster/awload.py
+++ b/src/codeflare_sdk/cluster/awload.py
@@ -24,7 +24,7 @@ import yaml
 
 from kubernetes import client, config
 from ..utils.kube_api_helpers import _kube_api_error_handling
-from .auth import config_check, api_config_handler
+from .auth import config_check, get_api_client
 
 
 class AWManager:
@@ -59,7 +59,7 @@ class AWManager:
         """
         try:
             config_check()
-            api_instance = client.CustomObjectsApi(api_config_handler())
+            api_instance = client.CustomObjectsApi(get_api_client())
             api_instance.create_namespaced_custom_object(
                 group="workload.codeflare.dev",
                 version="v1beta2",
@@ -84,7 +84,7 @@ class AWManager:
 
         try:
             config_check()
-            api_instance = client.CustomObjectsApi(api_config_handler())
+            api_instance = client.CustomObjectsApi(get_api_client())
             api_instance.delete_namespaced_custom_object(
                 group="workload.codeflare.dev",
                 version="v1beta2",

--- a/src/codeflare_sdk/cluster/widgets.py
+++ b/src/codeflare_sdk/cluster/widgets.py
@@ -29,7 +29,7 @@ import pandas as pd
 from .config import ClusterConfiguration
 from .model import RayClusterStatus
 from ..utils.kube_api_helpers import _kube_api_error_handling
-from .auth import config_check, api_config_handler
+from .auth import config_check, get_api_client
 
 
 def cluster_up_down_buttons(cluster: "codeflare_sdk.cluster.Cluster") -> widgets.Button:
@@ -343,7 +343,7 @@ def _delete_cluster(
 
     try:
         config_check()
-        api_instance = client.CustomObjectsApi(api_config_handler())
+        api_instance = client.CustomObjectsApi(get_api_client())
 
         if _check_aw_exists(cluster_name, namespace):
             api_instance.delete_namespaced_custom_object(

--- a/src/codeflare_sdk/utils/generate_cert.py
+++ b/src/codeflare_sdk/utils/generate_cert.py
@@ -19,7 +19,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography import x509
 from cryptography.x509.oid import NameOID
 import datetime
-from ..cluster.auth import config_check, api_config_handler
+from ..cluster.auth import config_check, get_api_client
 from kubernetes import client, config
 from .kube_api_helpers import _kube_api_error_handling
 
@@ -103,7 +103,7 @@ def generate_tls_cert(cluster_name, namespace, days=30):
     # oc get secret ca-secret-<cluster-name> -o template='{{index .data "ca.key"}}'
     # oc get secret ca-secret-<cluster-name> -o template='{{index .data "ca.crt"}}'|base64 -d > ${TLSDIR}/ca.crt
     config_check()
-    v1 = client.CoreV1Api(api_config_handler())
+    v1 = client.CoreV1Api(get_api_client())
 
     # Secrets have a suffix appended to the end so we must list them and gather the secret that includes cluster_name-ca-secret-
     secret_name = get_secret_name(cluster_name, namespace, v1)

--- a/src/codeflare_sdk/utils/generate_yaml.py
+++ b/src/codeflare_sdk/utils/generate_yaml.py
@@ -27,7 +27,7 @@ import argparse
 import uuid
 from kubernetes import client, config
 from .kube_api_helpers import _kube_api_error_handling
-from ..cluster.auth import api_config_handler, config_check
+from ..cluster.auth import get_api_client, config_check
 from os import urandom
 from base64 import b64encode
 from urllib3.util import parse_url
@@ -57,7 +57,7 @@ def gen_names(name):
 def is_openshift_cluster():
     try:
         config_check()
-        for api in client.ApisApi(api_config_handler()).get_api_versions().groups:
+        for api in client.ApisApi(get_api_client()).get_api_versions().groups:
             for v in api.versions:
                 if "route.openshift.io/v1" in v.group_version:
                     return True
@@ -235,7 +235,7 @@ def get_default_kueue_name(namespace: str):
     # If the local queue is set, use it. Otherwise, try to use the default queue.
     try:
         config_check()
-        api_instance = client.CustomObjectsApi(api_config_handler())
+        api_instance = client.CustomObjectsApi(get_api_client())
         local_queues = api_instance.list_namespaced_custom_object(
             group="kueue.x-k8s.io",
             version="v1beta1",
@@ -261,7 +261,7 @@ def local_queue_exists(namespace: str, local_queue_name: str):
     # get all local queues in the namespace
     try:
         config_check()
-        api_instance = client.CustomObjectsApi(api_config_handler())
+        api_instance = client.CustomObjectsApi(get_api_client())
         local_queues = api_instance.list_namespaced_custom_object(
             group="kueue.x-k8s.io",
             version="v1beta1",

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -134,7 +134,7 @@ def test_token_auth_creation():
         assert token_auth.skip_tls == True
         assert token_auth.ca_cert_path == None
 
-        os.environ["CF_SDK_CA_CERT_PATH"] = f"/etc/pki/tls/custom-certs/ca-bundle.crt"
+        os.environ["CF_SDK_CA_CERT_PATH"] = "/etc/pki/tls/custom-certs/ca-bundle.crt"
         token_auth = TokenAuthentication(token="token", server="server", skip_tls=False)
         assert token_auth.token == "token"
         assert token_auth.server == "server"
@@ -153,7 +153,7 @@ def test_token_auth_creation():
         assert token_auth.skip_tls == False
         assert token_auth.ca_cert_path == f"{parent}/tests/auth-test.crt"
 
-    except Exception:
+    except Exception as e:
         assert 0 == 1
 
 
@@ -294,6 +294,7 @@ def test_cluster_creation(mocker):
     )
 
 
+@patch.dict("os.environ", {"NB_PREFIX": "test-prefix"})
 def test_cluster_no_kueue_no_aw(mocker):
     mocker.patch("kubernetes.client.ApisApi.get_api_versions")
     mocker.patch(
@@ -301,7 +302,6 @@ def test_cluster_no_kueue_no_aw(mocker):
         return_value={"spec": {"domain": "apps.cluster.awsroute.org"}},
     )
     mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
-    mocker.patch("os.environ.get", return_value="test-prefix")
     config = createClusterConfig()
     config.appwrapper = False
     config.name = "unit-test-no-kueue"
@@ -350,6 +350,7 @@ def get_local_queue(group, version, namespace, plural):
     return local_queues
 
 
+@patch.dict("os.environ", {"NB_PREFIX": "test-prefix"})
 def test_cluster_creation_no_mcad(mocker):
     # Create Ray Cluster with no local queue specified
     mocker.patch("kubernetes.client.ApisApi.get_api_versions")
@@ -361,7 +362,6 @@ def test_cluster_creation_no_mcad(mocker):
         "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
         return_value=get_local_queue("kueue.x-k8s.io", "v1beta1", "ns", "localqueues"),
     )
-    mocker.patch("os.environ.get", return_value="test-prefix")
 
     config = createClusterConfig()
     config.name = "unit-test-cluster-ray"
@@ -379,6 +379,7 @@ def test_cluster_creation_no_mcad(mocker):
     )
 
 
+@patch.dict("os.environ", {"NB_PREFIX": "test-prefix"})
 def test_cluster_creation_no_mcad_local_queue(mocker):
     # With written resources
     # Create Ray Cluster with local queue specified
@@ -391,7 +392,6 @@ def test_cluster_creation_no_mcad_local_queue(mocker):
         "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
         return_value=get_local_queue("kueue.x-k8s.io", "v1beta1", "ns", "localqueues"),
     )
-    mocker.patch("os.environ.get", return_value="test-prefix")
     config = createClusterConfig()
     config.name = "unit-test-cluster-ray"
     config.appwrapper = False
@@ -460,6 +460,7 @@ def test_default_cluster_creation(mocker):
     assert cluster.config.namespace == "opendatahub"
 
 
+@patch.dict("os.environ", {"NB_PREFIX": "test-prefix"})
 def test_cluster_creation_with_custom_image(mocker):
     # With written resources
     # Create Ray Cluster with local queue specified
@@ -472,7 +473,6 @@ def test_cluster_creation_with_custom_image(mocker):
         "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
         return_value=get_local_queue("kueue.x-k8s.io", "v1beta1", "ns", "localqueues"),
     )
-    mocker.patch("os.environ.get", return_value="test-prefix")
     config = createClusterConfig()
     config.name = "unit-test-cluster-custom-image"
     config.appwrapper = False
@@ -2170,7 +2170,7 @@ def test_map_to_ray_cluster(mocker):
 
     mock_api_client = mocker.MagicMock(spec=client.ApiClient)
     mocker.patch(
-        "codeflare_sdk.cluster.auth.api_config_handler", return_value=mock_api_client
+        "codeflare_sdk.cluster.auth.get_api_client", return_value=mock_api_client
     )
 
     mock_routes = {


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-12802
# What changes have been made
If the user logged in using `oc login ...` the self signed CA cert wasn't being picked up

# Verification steps
Use `oc login` in a ODH cluster with self signed certs. The user should be able to create Ray Clusters without doing anything special

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->