### PR TITLE
move current namespace logic to config

### DIFF
--- a/src/codeflare_sdk/cluster/auth.py
+++ b/src/codeflare_sdk/cluster/auth.py
@@ -219,3 +219,25 @@ def api_config_handler() -> Optional[client.ApiClient]:
         return api_client
     else:
         return None
+
+
+def get_current_namespace():  # pragma: no cover
+    config_check()
+    if os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"):
+        try:
+            file = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r")
+            active_context = file.readline().strip("\n")
+            return active_context
+        except Exception as e:
+            print("Unable to find current namespace")
+    if api_config_handler() is not None:
+        return None
+    print("trying to gather from current context")
+    try:
+        _, active_context = config.list_kube_config_contexts(config_check())
+    except Exception as e:
+        return _kube_api_error_handling(e)
+    try:
+        return active_context["context"]["namespace"]
+    except KeyError:
+        return None

--- a/src/codeflare_sdk/cluster/cluster.py
+++ b/src/codeflare_sdk/cluster/cluster.py
@@ -110,15 +110,6 @@ class Cluster:
         the specifications of the ClusterConfiguration.
         """
 
-        if self.config.namespace is None:
-            self.config.namespace = get_current_namespace()
-            if self.config.namespace is None:
-                print("Please specify with namespace=<your_current_namespace>")
-            elif type(self.config.namespace) is not str:
-                raise TypeError(
-                    f"Namespace {self.config.namespace} is of type {type(self.config.namespace)}. Check your Kubernetes Authentication."
-                )
-
         return generate_appwrapper(self)
 
     # creates a new cluster with the provided or default spec
@@ -545,28 +536,6 @@ def list_all_queued(
     return resources
 
 
-def get_current_namespace():  # pragma: no cover
-    if os.path.isfile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"):
-        try:
-            file = open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r")
-            active_context = file.readline().strip("\n")
-            return active_context
-        except Exception as e:
-            print("Unable to find current namespace")
-
-    if api_config_handler() != None:
-        return None
-    print("trying to gather from current context")
-    try:
-        _, active_context = config.list_kube_config_contexts(config_check())
-    except Exception as e:
-        return _kube_api_error_handling(e)
-    try:
-        return active_context["context"]["namespace"]
-    except KeyError:
-        return None
-
-
 def get_cluster(
     cluster_name: str,
     namespace: str = "default",
@@ -645,14 +614,9 @@ def _check_aw_exists(name: str, namespace: str) -> bool:
     return False
 
 
-# Cant test this until get_current_namespace is fixed and placed in this function over using `self`
 def _get_ingress_domain(self):  # pragma: no cover
     config_check()
 
-    if self.config.namespace != None:
-        namespace = self.config.namespace
-    else:
-        namespace = get_current_namespace()
     domain = None
 
     if is_openshift_cluster():

--- a/src/codeflare_sdk/cluster/config.py
+++ b/src/codeflare_sdk/cluster/config.py
@@ -23,6 +23,8 @@ import warnings
 from dataclasses import dataclass, field, fields
 from typing import Dict, List, Optional, Union, get_args, get_origin
 
+from .auth import get_current_namespace
+
 dir = pathlib.Path(__file__).parent.parent.resolve()
 
 # https://docs.ray.io/en/latest/ray-core/scheduling/accelerators.html
@@ -122,6 +124,13 @@ class ClusterConfiguration:
         self._validate_extended_resource_requests(
             self.worker_extended_resource_requests
         )
+        if self.namespace is None:
+            self.namespace = get_current_namespace()
+            print(f"Namespace not provided, using current namespace: {self.namespace}")
+        if self.namespace is None:
+            raise ValueError(
+                "Namespace not provided and unable to determine current namespace"
+            )
 
     def _combine_extended_resource_mapping(self):
         if overwritten := set(self.extended_resource_mapping.keys()).intersection(

--- a/tests/unit_test.py
+++ b/tests/unit_test.py
@@ -433,7 +433,7 @@ def test_cluster_creation_no_mcad_local_queue(mocker):
 def test_default_cluster_creation(mocker):
     mocker.patch("kubernetes.client.ApisApi.get_api_versions")
     mocker.patch(
-        "codeflare_sdk.cluster.cluster.get_current_namespace",
+        "codeflare_sdk.cluster.auth.get_current_namespace",
         return_value="opendatahub",
     )
     mocker.patch(
@@ -2664,7 +2664,7 @@ def test_export_env():
 def test_cluster_throw_for_no_raycluster(mocker: MockerFixture):
     mocker.patch("kubernetes.client.ApisApi.get_api_versions")
     mocker.patch(
-        "codeflare_sdk.cluster.cluster.get_current_namespace",
+        "codeflare_sdk.cluster.auth.get_current_namespace",
         return_value="opendatahub",
     )
     mocker.patch(


### PR DESCRIPTION
# What changes have been made
I was running into some issues testing locally without specifying a namespace. I realized we could default early and make the error much clearer

# Verification steps
Use the codeflare_sdk in a jupyter nb locally and don't specify namespace in your cluster configuration

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->