### PR TITLE
Updating ray image to use sha rather than floating tag

### DIFF
--- a/src/codeflare_sdk/templates/base-template.yaml
+++ b/src/codeflare_sdk/templates/base-template.yaml
@@ -69,7 +69,7 @@ spec:
         containers:
         # The Ray head pod
         - name: ray-head
-          image: quay.io/modh/ray:2.35.0-py39-cu121
+          image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
           imagePullPolicy: Always
           ports:
           - containerPort: 6379
@@ -150,7 +150,7 @@ spec:
       spec:
         containers:
         - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: quay.io/modh/ray:2.35.0-py39-cu121
+          image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           lifecycle:

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -8,7 +8,7 @@ from codeflare_sdk.utils.kube_api_helpers import _kube_api_error_handling
 
 
 def get_ray_image():
-    default_ray_image = "quay.io/modh/ray:2.35.0-py39-cu121"
+    default_ray_image = "quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283"
     return os.getenv("RAY_IMAGE", default_ray_image)
 
 

--- a/tests/test-case-bad.yaml
+++ b/tests/test-case-bad.yaml
@@ -43,7 +43,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: status.podIP
-                image: quay.io/modh/ray:2.35.0-py39-cu121
+                image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
                 imagePullPolicy: Always
                 lifecycle:
                   preStop:
@@ -90,7 +90,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: status.podIP
-                image: quay.io/modh/ray:2.35.0-py39-cu121
+                image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
                 lifecycle:
                   preStop:
                     exec:

--- a/tests/test-case-no-kueue-no-aw.yaml
+++ b/tests/test-case-no-kueue-no-aw.yaml
@@ -31,7 +31,7 @@ spec:
     template:
       spec:
         containers:
-        - image: quay.io/modh/ray:2.35.0-py39-cu121
+        - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
           imagePullPolicy: Always
           lifecycle:
             preStop:
@@ -103,7 +103,7 @@ spec:
           key: value
       spec:
         containers:
-        - image: quay.io/modh/ray:2.35.0-py39-cu121
+        - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
           lifecycle:
             preStop:
               exec:

--- a/tests/test-case-no-mcad.yamls
+++ b/tests/test-case-no-mcad.yamls
@@ -34,7 +34,7 @@ spec:
     template:
       spec:
         containers:
-        - image: quay.io/modh/ray:2.35.0-py39-cu121
+        - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
           imagePullPolicy: Always
           lifecycle:
             preStop:
@@ -106,7 +106,7 @@ spec:
           key: value
       spec:
         containers:
-        - image: quay.io/modh/ray:2.35.0-py39-cu121
+        - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
           lifecycle:
             preStop:
               exec:

--- a/tests/test-case.yaml
+++ b/tests/test-case.yaml
@@ -39,7 +39,7 @@ spec:
           template:
             spec:
               containers:
-              - image: quay.io/modh/ray:2.35.0-py39-cu121
+              - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
                 imagePullPolicy: Always
                 lifecycle:
                   preStop:
@@ -111,7 +111,7 @@ spec:
                 key: value
             spec:
               containers:
-              - image: quay.io/modh/ray:2.35.0-py39-cu121
+              - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
                 lifecycle:
                   preStop:
                     exec:

--- a/tests/test-default-appwrapper.yaml
+++ b/tests/test-default-appwrapper.yaml
@@ -40,7 +40,7 @@ spec:
             spec:
               imagePullSecrets: []
               containers:
-              - image: quay.io/modh/ray:2.35.0-py39-cu121
+              - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
                 imagePullPolicy: Always
                 lifecycle:
                   preStop:
@@ -111,7 +111,7 @@ spec:
             spec:
               imagePullSecrets: []
               containers:
-              - image: quay.io/modh/ray:2.35.0-py39-cu121
+              - image: quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283
                 lifecycle:
                   preStop:
                     exec:

--- a/tests/unit_test_support.py
+++ b/tests/unit_test_support.py
@@ -45,7 +45,7 @@ def createClusterWrongType():
         appwrapper=True,
         machine_types=[True, False],
         image_pull_secrets=["unit-test-pull-secret"],
-        image="quay.io/modh/ray:2.35.0-py39-cu121",
+        image="quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283",
         write_to_file=True,
         labels={1: 1},
     )


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Related to [RHOAIENG-12186](https://issues.redhat.com/browse/RHOAIENG-12186)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Updating Ray image references to `http://quay.io/modh/ray@sha256:83084b89885232e5733027b2ee45b83d3642ce32ae0b8e18b79ed45b6e734283` using static SHA tag rather than floating tag used previously - this is of benefit specifically in a disconnected environment.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

- Run the interactive demo notebooks from this PR and enure that they work as expected.
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->