### PR TITLE
fix: skip_tls authentication functionality

### DIFF
--- a/src/codeflare_sdk/common/kubernetes_cluster/auth.py
+++ b/src/codeflare_sdk/common/kubernetes_cluster/auth.py
@@ -109,13 +109,14 @@ class TokenAuthentication(Authentication):
             configuration.host = self.server
             configuration.api_key["authorization"] = self.token
 
-            api_client = client.ApiClient(configuration)
-            if not self.skip_tls:
-                _client_with_cert(api_client, self.ca_cert_path)
-            else:
+            if self.skip_tls:
                 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
                 print("Insecure request warnings have been disabled")
                 configuration.verify_ssl = False
+
+            api_client = client.ApiClient(configuration)
+            if not self.skip_tls:
+                _client_with_cert(api_client, self.ca_cert_path)
 
             client.AuthenticationApi(api_client).get_api_group()
             config_path = None


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Closes: [RHOAIENG-14012](https://issues.redhat.com/browse/RHOAIENG-14012)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Changed verification configuration setting to occur before `api_client()` is initialised.
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
* Get access to an insecure OpenShift Cluster.
* Authenticate using token + server with `skip_tls=True`
* Ensure you have successfully authenticated
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->