### PR TITLE
Dynamic notebooks sync workflow

### DIFF
--- a/.github/workflows/odh-notebooks-sync.yml
+++ b/.github/workflows/odh-notebooks-sync.yml
@@ -7,7 +7,14 @@ on:
         required: true
         description: "Owner of target upstream notebooks repository used to open a PR against"
         default: "opendatahub-io"
-
+      notebooks-target-branch:
+        required: true
+        description: "Target branch of upstream repository"
+        default: "main"
+      python-version:
+        required: true
+        description: "Provide the python version to be used for the notebooks"
+        default: "3.11"
       codeflare-repository-organization:
         required: true
         description: "Owner of origin notebooks repository used to open a PR"
@@ -18,7 +25,8 @@ on:
         description: "Provide version of the Codeflare-SDK release"
 
 env:
-  BRANCH_NAME: main
+  BRANCH_NAME: ${{ github.event.inputs.notebooks-target-branch }}
+  PYTHON_VERSION: ${{ github.event.inputs.python-version }}
   CODEFLARE_RELEASE_VERSION: ${{ github.event.inputs.codeflare_sdk_release_version }}
   UPDATER_BRANCH: odh-sync-updater-${{ github.run_id }}
   UPSTREAM_OWNER: ${{ github.event.inputs.upstream-repository-organization }}
@@ -39,23 +47,24 @@ jobs:
           git config --global user.email "138894154+codeflare-machine-account@users.noreply.github.com"
           git config --global user.name "codeflare-machine-account"
           git remote -v
-          git pull upstream main && git push origin main
+          git fetch upstream $BRANCH_NAME
+          git checkout $BRANCH_NAME
 
       - name: Setup Python environment
         uses: actions/setup-python@v4
         with:
-          python-version: |
-            3.9
-            3.11
+          python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pipenv'
 
+      # Sync fails with pipenv 2024.1.0 (current latest version)
+      # TODO: We should retry with later versions of pipenv once they are available.
       - name: Install pipenv and pip-versions
-        run: pip install pipenv pip-versions
+        run: pip install pipenv==2024.0.3 pip-versions
 
       - name: Update Pipfiles in accordance with Codeflare-SDK latest release
         run: |
           package_name=codeflare-sdk
-          available_python_versions=("3.9" "3.11") # add space separated python versions according to 'python-versions' specified in 'Setup Python Environment' step
+          available_python_versions=("$PYTHON_VERSION") # add space separated python versions according to 'python-versions' specified in 'Setup Python Environment' step
           install_package_using_pipenv(){
             # args allow custom names for Pipfile and Pipfile.lock
             if [ $# -eq 2 ]; then


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Related Jira: https://issues.redhat.com/browse/RHOAIENG-14201 
Jira: https://issues.redhat.com/browse/RHOAIENG-14203 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
With this change, we can dispatch the notebooks sync workflow by also providing the specific python version and target branch name, i.e., [release-2024a](https://github.com/opendatahub-io/notebooks/tree/2024a) for Notebooks with py3.9.

Additionally, pipenv version has been pinned to use version `2024.0.3` as latest version `2024.1.0` seems to break the workflow. I added a TODO to retry on later major/minor versions of pipenv once available.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Workflow run for py3.9: https://github.com/project-codeflare/codeflare-sdk/actions/runs/11324720561 
Generated PR for py3.9 in my fork: https://github.com/ChristianZaccaria/notebooks/pull/3 
Workflow run for py3.11: https://github.com/project-codeflare/codeflare-sdk/actions/runs/11325885485/job/31493695580 
Generated PR for py3.11 in my fork: https://github.com/ChristianZaccaria/notebooks/pull/4 

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->