### PR TITLE
add function for listing lqs by flavors

### DIFF
--- a/src/codeflare_sdk/__init__.py
+++ b/src/codeflare_sdk/__init__.py
@@ -21,6 +21,10 @@ from .common import (
     KubeConfigFileAuthentication,
 )
 
+from .common.kueue import (
+    list_local_queues,
+)
+
 from .common.utils import generate_cert
 from .common.utils.demos import copy_demo_nbs
 

--- a/src/codeflare_sdk/common/kubernetes_cluster/kube_api_helpers.py
+++ b/src/codeflare_sdk/common/kubernetes_cluster/kube_api_helpers.py
@@ -20,6 +20,7 @@ API error handling or wrapping.
 import executing
 from kubernetes import client, config
 from urllib3.util import parse_url
+import os
 
 
 # private methods

--- a/src/codeflare_sdk/common/kueue/__init__.py
+++ b/src/codeflare_sdk/common/kueue/__init__.py
@@ -2,4 +2,5 @@ from .kueue import (
     get_default_kueue_name,
     local_queue_exists,
     add_queue_label,
+    list_local_queues,
 )

--- a/src/codeflare_sdk/common/kueue/kueue.py
+++ b/src/codeflare_sdk/common/kueue/kueue.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import Optional, List
 from codeflare_sdk.common import _kube_api_error_handling
 from codeflare_sdk.common.kubernetes_cluster.auth import config_check, get_api_client
 from kubernetes import client
@@ -43,6 +43,53 @@ def get_default_kueue_name(namespace: str):
             == "true"
         ):
             return lq["metadata"]["name"]
+
+
+def list_local_queues(
+    namespace: Optional[str] = None, flavors: Optional[List[str]] = None
+) -> List[dict]:
+    """
+    This function lists all local queues in the namespace provided.
+
+    If no namespace is provided, it will use the current namespace. If flavors is provided, it will only return local
+    queues that support all the flavors provided.
+
+    Note:
+        Depending on the version of the local queue API, the available flavors may not be present in the response.
+
+    Args:
+        namespace (str, optional): The namespace to list local queues from. Defaults to None.
+        flavors (List[str], optional): The flavors to filter local queues by. Defaults to None.
+    Returns:
+        List[dict]: A list of dictionaries containing the name of the local queue and the available flavors
+    """
+
+    from ...ray.cluster.cluster import get_current_namespace
+
+    if namespace is None:  # pragma: no cover
+        namespace = get_current_namespace()
+    try:
+        config_check()
+        api_instance = client.CustomObjectsApi(get_api_client())
+        local_queues = api_instance.list_namespaced_custom_object(
+            group="kueue.x-k8s.io",
+            version="v1beta1",
+            namespace=namespace,
+            plural="localqueues",
+        )
+    except ApiException as e:  # pragma: no cover
+        return _kube_api_error_handling(e)
+    to_return = []
+    for lq in local_queues["items"]:
+        item = {"name": lq["metadata"]["name"]}
+        if "flavors" in lq["status"]:
+            item["flavors"] = [f["name"] for f in lq["status"]["flavors"]]
+            if flavors is not None and not set(flavors).issubset(set(item["flavors"])):
+                continue
+        elif flavors is not None:
+            continue  # NOTE: may be indicative old local queue API and might be worth while raising or warning here
+        to_return.append(item)
+    return to_return
 
 
 def local_queue_exists(namespace: str, local_queue_name: str):


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/RHOAIENG-13429

# What changes have been made
This lists local queues available to a user as well as the flavors for that LQ if available

# Verification steps
make and deploy kueue with latest changes from https://github.com/opendatahub-io/kueue/pull/52

Create Flavors, LQs, and CQ

```
from codeflare_sdk.common.kueue import list_local_queues

list_local_queues(...)
```
will update with more details when cluster resumes

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->