### PR TITLE
Intuit python version for compatible Ray image

### DIFF
--- a/demo-notebooks/additional-demos/hf_interactive.ipynb
+++ b/demo-notebooks/additional-demos/hf_interactive.ipynb
@@ -68,8 +68,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding Ray Cluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/additional-demos/local_interactive.ipynb
+++ b/demo-notebooks/additional-demos/local_interactive.ipynb
@@ -35,8 +35,12 @@
    "metadata": {},
    "source": [
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/additional-demos/ray_job_client.ipynb
+++ b/demo-notebooks/additional-demos/ray_job_client.ipynb
@@ -41,8 +41,12 @@
    "metadata": {},
    "source": [
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/0_basic_ray.ipynb
@@ -47,8 +47,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
@@ -41,8 +41,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/2_basic_interactive.ipynb
@@ -44,8 +44,12 @@
    "source": [
     "Once again, let's start by running through the same cluster setup as before:\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/3_widget_example.ipynb
+++ b/demo-notebooks/guided-demos/3_widget_example.ipynb
@@ -47,8 +47,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
@@ -47,8 +47,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
@@ -41,8 +41,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
@@ -44,8 +44,12 @@
    "source": [
     "Once again, let's start by running through the same cluster setup as before:\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
@@ -47,8 +47,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
@@ -41,8 +41,12 @@
    "source": [
     "Here, we want to define our cluster by specifying the resources we require for our batch workload. Below, we define our cluster object (which generates a corresponding RayCluster).\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
@@ -44,8 +44,12 @@
    "source": [
     "Once again, let's start by running through the same cluster setup as before:\n",
     "\n",
-    "NOTE: 'quay.io/modh/ray:2.35.0-py39-cu121' is the default image used by the CodeFlare SDK for creating a RayCluster resource. \n",
-    "If you have your own Ray image which suits your purposes, specify it in image field to override the default image."
+    "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
+    "\n",
+    "- For Python 3.9: 'quay.io/modh/ray:2.35.0-py39-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "\n",
+    "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]
   },
   {

--- a/docs/sphinx/user-docs/cluster-configuration.rst
+++ b/docs/sphinx/user-docs/cluster-configuration.rst
@@ -30,10 +30,15 @@ requirements for creating the Ray Cluster.
    ))
 
 .. note::
-  `quay.io/modh/ray:2.35.0-py39-cu121` is the default image used by
-  the CodeFlare SDK for creating a RayCluster resource. If you have your
-  own Ray image which suits your purposes, specify it in image field to
-  override the default image. If you are using ROCm compatible GPUs you
+  The default images used by the CodeFlare SDK for creating
+  a RayCluster resource depend on the installed Python version:
+
+  - For Python 3.9: `quay.io/modh/ray:2.35.0-py39-cu121`
+  - For Python 3.11: `quay.io/modh/ray:2.35.0-py311-cu121`
+
+  If you prefer to use a custom Ray image that better suits your
+  needs, you can specify it in the image field to override the default.
+  If you are using ROCm compatible GPUs you
   can use `quay.io/modh/ray:2.35.0-py39-rocm61`. You can also find
   documentation on building a custom image
   `here <https://github.com/opendatahub-io/distributed-workloads/tree/main/images/runtime/examples>`__.

--- a/src/codeflare_sdk/ray/cluster/generate_yaml.py
+++ b/src/codeflare_sdk/ray/cluster/generate_yaml.py
@@ -20,6 +20,7 @@ This sub-module exists primarily to be used internally by the Cluster object
 import json
 import sys
 import typing
+import warnings
 import yaml
 import os
 import uuid
@@ -34,7 +35,7 @@ import codeflare_sdk
 
 SUPPORTED_PYTHON_VERSIONS = {
     "3.9": "quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06",
-    "3.11": "quay.io/modh/ray:2.35.0-py311-cu121",
+    "3.11": "quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4",
 }
 
 
@@ -96,12 +97,11 @@ def update_image(spec, image):
     containers = spec.get("containers")
     if not image:
         python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-        try:
-            if python_version in SUPPORTED_PYTHON_VERSIONS:
-                image = SUPPORTED_PYTHON_VERSIONS[python_version]
-        except Exception:  # pragma: no cover
-            print(
-                f"Python version '{python_version}' is not supported. Only {', '.join(SUPPORTED_PYTHON_VERSIONS.keys())} are supported."
+        if python_version in SUPPORTED_PYTHON_VERSIONS:
+            image = SUPPORTED_PYTHON_VERSIONS[python_version]
+        else:
+            warnings.warn(
+                f"No default Ray image defined for {python_version}. Please provide your own image or use one of the following python versions: {', '.join(SUPPORTED_PYTHON_VERSIONS.keys())}."
             )
     for container in containers:
         container["image"] = image

--- a/src/codeflare_sdk/ray/templates/base-template.yaml
+++ b/src/codeflare_sdk/ray/templates/base-template.yaml
@@ -69,7 +69,6 @@ spec:
         containers:
         # The Ray head pod
         - name: ray-head
-          image: quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
           imagePullPolicy: Always
           ports:
           - containerPort: 6379
@@ -150,7 +149,6 @@ spec:
       spec:
         containers:
         - name: machine-learning # must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc'
-          image: quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
           # environment variables to set in the container.Optional.
           # Refer to https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
           lifecycle:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-14578 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
The Ray image to be used by the head and worker nodes will be based on the python version in the system.

Currently, we support py3.9, and we will now support Ray with py3.11.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
1. Launch a jupyter notebook server with python3.9.
2. Run through the `0_basic_ray.ipynb` notebook with the `write_to_file` parameter set to `True`.
3. See the Ray image used in the head and worker group specs.
4. Repeat but with python3.11.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->