### PR TITLE
Dependabot Enhancements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
         update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 4
     labels:
+      - "dependabot"
       - "test-guided-notebooks"
 
   # pip means poetry in this case, this keeps poetry.lock up to date with constraints in pyproject.toml.
@@ -27,6 +28,7 @@ updates:
         update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 1
     labels:
+      - "dependabot"
       - "test-guided-notebooks"
 
   # npm means yarn in this case, this keeps yarn.lock up to date with constraints in package.json.
@@ -39,4 +41,5 @@ updates:
         update-types: ["version-update:semver-patch"]
     open-pull-requests-limit: 1
     labels:
+      - "dependabot"
       - "test-ui-notebooks"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,18 +4,16 @@
 version: 2
 updates:
   # This is to update requirements.txt files in the guided-demos, and e2e directories.
-  # The group configuration option is used to group updates for consistency across related directories.
   - package-ecosystem: "pip"
     directories:
       - "**/demo-notebooks/guided-demos*"
       - "/tests/e2e"
     schedule:
-      interval: "weekly"
-    groups:
-      requirements.txt:
-        patterns:
-          - "*"
-    open-pull-requests-limit: 10
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 4
     labels:
       - "test-guided-notebooks"
 
@@ -23,7 +21,22 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 1
     labels:
       - "test-guided-notebooks"
+
+  # npm means yarn in this case, this keeps yarn.lock up to date with constraints in package.json.
+  - package-ecosystem: "npm"
+    directory: "/ui-tests"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    open-pull-requests-limit: 1
+    labels:
+      - "test-ui-notebooks"

--- a/.github/workflows/dependabot-labeler.yaml
+++ b/.github/workflows/dependabot-labeler.yaml
@@ -4,12 +4,22 @@ name: Dependabot Labeler
 
 on:
   pull_request:
+    types: [ labeled, synchronize, opened, reopened ]
 
 jobs:
     add-approve-lgtm-label:
-        if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependabot')
+        if: ${{ github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependabot') }}
         runs-on: ubuntu-latest
+
+        # Permission required to edit a PR
+        permissions:
+          pull-requests: write
+          issues: write
+
         steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
             - name: Add approve and lgtm labels to Dependabot PR
               run: |
                   gh pr edit ${{ github.event.pull_request.number }} --add-label "lgtm" --add-label "approved"

--- a/.github/workflows/dependabot-labeler.yaml
+++ b/.github/workflows/dependabot-labeler.yaml
@@ -1,0 +1,17 @@
+# This workflow file adds the 'lgtm' and 'approved' labels to Dependabot PRs
+# This is done to ensure that the PRs that pass e2e are automatically merged/added to merge-queues by the CodeFlare bot
+name: Dependabot Labeler
+
+on:
+  pull_request:
+
+jobs:
+    add-approve-lgtm-label:
+        if: github.actor == 'dependabot[bot]'
+        runs-on: ubuntu-latest
+        steps:
+            - name: Add approve and lgtm labels to Dependabot PR
+              run: |
+                  gh pr edit ${{ github.event.pull_request.number }} --add-label "lgtm" --add-label "approved"
+              env:
+                GITHUB_TOKEN: ${{ secrets.CODEFLARE_MACHINE_ACCOUNT_TOKEN }}

--- a/.github/workflows/dependabot-labeler.yaml
+++ b/.github/workflows/dependabot-labeler.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     add-approve-lgtm-label:
-        if: github.actor == 'dependabot[bot]'
+        if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'dependabot')
         runs-on: ubuntu-latest
         steps:
             - name: Add approve and lgtm labels to Dependabot PR

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -19,6 +19,7 @@ on:
       - '**.adoc'
       - '**.md'
       - 'LICENSE'
+  merge_group:
 
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -2,6 +2,7 @@ name: e2e
 
 on:
   pull_request:
+    types: [ labeled, synchronize, opened, reopened ]
     branches:
       - main
       - 'release-*'

--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -30,7 +30,7 @@ env:
 
 jobs:
   kubernetes:
-
+    if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.event_name == 'merge_group'
     runs-on: ubuntu-20.04-4core-gpu
 
     steps:

--- a/.github/workflows/guided_notebook_tests.yaml
+++ b/.github/workflows/guided_notebook_tests.yaml
@@ -2,7 +2,6 @@ name: Guided notebooks tests
 
 on:
   pull_request:
-    types: [ labeled ]
 
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}
@@ -13,7 +12,7 @@ env:
 
 jobs:
   verify-0_basic_ray:
-    if: ${{ github.event.label.name == 'test-guided-notebooks' }}
+    if: contains(github.event.pull_request.labels.*.name, 'test-guided-notebooks')
     runs-on: ubuntu-20.04-4core
 
     steps:

--- a/.github/workflows/guided_notebook_tests.yaml
+++ b/.github/workflows/guided_notebook_tests.yaml
@@ -2,6 +2,7 @@ name: Guided notebooks tests
 
 on:
   pull_request:
+    types: [ labeled, synchronize, opened, reopened ]
 
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -7,6 +7,7 @@ on:
       - 'v*'
   pull_request:
   workflow_dispatch:
+  merge_group:
 
 jobs:
   precommit:

--- a/.github/workflows/ui_notebooks_test.yaml
+++ b/.github/workflows/ui_notebooks_test.yaml
@@ -2,6 +2,7 @@ name: UI notebooks tests
 
 on:
   pull_request:
+    types: [ labeled, synchronize, opened, reopened ]
 
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}

--- a/.github/workflows/ui_notebooks_test.yaml
+++ b/.github/workflows/ui_notebooks_test.yaml
@@ -2,7 +2,6 @@ name: UI notebooks tests
 
 on:
   pull_request:
-    types: [labeled]
 
 concurrency:
   group: ${{ github.head_ref }}-${{ github.workflow }}
@@ -13,7 +12,7 @@ env:
 
 jobs:
   verify-3_widget_example:
-    if: ${{ github.event.label.name == 'test-guided-notebooks' || github.event.label.name == 'test-ui-notebooks'}}
+    if: contains(github.event.pull_request.labels.*.name, 'test-guided-notebooks') || contains(github.event.pull_request.labels.*.name, 'test-ui-notebooks')
     runs-on: ubuntu-20.04-4core
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
 
 jobs:
   unit-tests:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Jira: https://issues.redhat.com/browse/RHOAIENG-11457 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Note: in this repository I have enabled merge queues in the `main` branch + in a [dummy branch](https://github.com/project-codeflare/codeflare-sdk/tree/test-odh-notebooks-sync) for testing purposes.
- Ignore updating patch versions to focus on major and minor updates.
- Limit number of PRs opened.
- Add dependabot labeler workflow to add required labels to automatically add PRs to merge queues.
- Add merge_group condition on test workflows to be ran on merge queues.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Merge queues:
1. I added changes from this PR to a [dummy branch](https://github.com/project-codeflare/codeflare-sdk/tree/test-odh-notebooks-sync).
2. I created Dummy PR 1: https://github.com/project-codeflare/codeflare-sdk/pull/716 
3. I created Dummy PR 2: https://github.com/project-codeflare/codeflare-sdk/pull/717 
4. See both PRs were added to the [merge queue](https://github.com/project-codeflare/codeflare-sdk/queue/test-odh-notebooks-sync), and both were successfully merged at the exact same time.

Dependabot:
1. [PRs generated](https://github.com/ChristianZaccaria/codeflare-sdk/pulls?q=is%3Aopen+is%3Apr) in my fork for:
- `pyproject.toml` and `poetry.lock` files.
- `requirements.txt` files.
- `package.json` and `yarn.lock` files.

Once this PR is merged, we can make use of the CodeFlare Machine token to verify the Dependabot-Labeler workflow adds the required labels to add the Dependabot PRs to the merge queue.

# Points for discussion:
Before we merge, I would like to discuss with the team if we should perhaps change the way we merge PRs. To significantly reduce costs of using expensive GitHub Runners such as the ones with GPUs ran in e2e tests, perhaps the new flow could be:

> If PR passes all tests including pre-commit, unit-tests, and code-coverage (low costs), then the PR is added to the merge queue where the e2e test will run with changes from this PR and the number of all other PRs in the merge queue.

> If e2e fails, the PR is removed from the merge queue, if passes, the PR is merged with all other PRs in the merge queue.


This would mean, e2e tests will not run on each opened PR, or on each push, significantly reducing the running costs.

**Note:** we could still allow to run e2e tests in a PR triggered by a `non-merge-queue` label perhaps.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->