### PR TITLE
e2e test for heterogenous cluster

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -64,6 +64,8 @@ jobs:
 
       - name: Setup and start KinD cluster
         uses: ./common/github-actions/kind
+        with:
+          worker-nodes: 1
 
       - name: Install NVidia GPU operator for KinD
         uses: ./common/github-actions/nvidia-gpu-operator
@@ -102,6 +104,8 @@ jobs:
           kubectl create clusterrolebinding sdk-user-localqueue-creator --clusterrole=localqueue-creator --user=sdk-user
           kubectl create clusterrole list-secrets --verb=get,list --resource=secrets
           kubectl create clusterrolebinding sdk-user-list-secrets --clusterrole=list-secrets --user=sdk-user
+          kubectl create clusterrole pod-creator --verb=get,list --resource=pods
+          kubectl create clusterrolebinding sdk-user-pod-creator --clusterrole=pod-creator --user=sdk-user
           kubectl config use-context sdk-user
 
       - name: Run e2e tests

--- a/tests/e2e/heterogeneous_clusters_kind_test.py
+++ b/tests/e2e/heterogeneous_clusters_kind_test.py
@@ -1,0 +1,74 @@
+from time import sleep
+import time
+from codeflare_sdk import (
+    Cluster,
+    ClusterConfiguration,
+)
+
+from codeflare_sdk.common.kueue.kueue import list_local_queues
+
+import pytest
+
+from support import *
+
+
+@pytest.mark.skip(reason="Skipping heterogenous cluster kind test")
+@pytest.mark.kind
+class TestHeterogeneousClustersKind:
+    def setup_method(self):
+        initialize_kubernetes_client(self)
+
+    def teardown_method(self):
+        delete_namespace(self)
+        delete_kueue_resources(self)
+
+    @pytest.mark.nvidia_gpu
+    def test_heterogeneous_clusters(self):
+        create_namespace(self)
+        create_kueue_resources(self, 2)
+        self.run_heterogeneous_clusters()
+
+    def run_heterogeneous_clusters(
+        self, gpu_resource_name="nvidia.com/gpu", number_of_gpus=0
+    ):
+        for flavor in self.resource_flavors:
+            node_labels = (
+                get_flavor_spec(self, flavor).get("spec", {}).get("nodeLabels", {})
+            )
+            expected_nodes = get_nodes_by_label(self, node_labels)
+
+            print(f"Expected nodes: {expected_nodes}")
+            cluster_name = f"test-ray-cluster-li-{flavor[-5:]}"
+            queues = list_local_queues(namespace=self.namespace, flavors=[flavor])
+            queue_name = queues[0]["name"] if queues else None
+            print(f"Using flavor: {flavor}, Queue: {queue_name}")
+            cluster = Cluster(
+                ClusterConfiguration(
+                    name=cluster_name,
+                    namespace=self.namespace,
+                    num_workers=1,
+                    head_cpu_requests="500m",
+                    head_cpu_limits="500m",
+                    head_memory_requests=2,
+                    head_memory_limits=2,
+                    worker_cpu_requests="500m",
+                    worker_cpu_limits=1,
+                    worker_memory_requests=1,
+                    worker_memory_limits=4,
+                    worker_extended_resource_requests={
+                        gpu_resource_name: number_of_gpus
+                    },
+                    write_to_file=True,
+                    verify_tls=False,
+                    local_queue=queue_name,
+                )
+            )
+            cluster.up()
+            sleep(5)
+            node_name = get_pod_node(self, self.namespace, cluster_name)
+            print(f"Cluster {cluster_name}-{flavor} is running on node: {node_name}")
+            sleep(5)
+            assert (
+                node_name in expected_nodes
+            ), f"Node {node_name} is not in the expected nodes for flavor {flavor}."
+            cluster.down()

--- a/tests/e2e/heterogeneous_clusters_oauth_test.py
+++ b/tests/e2e/heterogeneous_clusters_oauth_test.py
@@ -1,0 +1,77 @@
+from time import sleep
+import time
+from codeflare_sdk import (
+    Cluster,
+    ClusterConfiguration,
+    TokenAuthentication,
+)
+
+from codeflare_sdk.common.kueue.kueue import list_local_queues
+
+import pytest
+
+from support import *
+
+
+@pytest.mark.openshift
+class TestHeterogeneousClustersOauth:
+    def setup_method(self):
+        initialize_kubernetes_client(self)
+
+    def teardown_method(self):
+        delete_namespace(self)
+        delete_kueue_resources(self)
+
+    def test_heterogeneous_clusters(self):
+        create_namespace(self)
+        create_kueue_resources(self, 2)
+        self.run_heterogeneous_clusters()
+
+    def run_heterogeneous_clusters(
+        self, gpu_resource_name="nvidia.com/gpu", number_of_gpus=0
+    ):
+        ray_image = get_ray_image()
+
+        auth = TokenAuthentication(
+            token=run_oc_command(["whoami", "--show-token=true"]),
+            server=run_oc_command(["whoami", "--show-server=true"]),
+            skip_tls=True,
+        )
+        auth.login()
+
+        for flavor in self.resource_flavors:
+            node_labels = (
+                get_flavor_spec(self, flavor).get("spec", {}).get("nodeLabels", {})
+            )
+            expected_nodes = get_nodes_by_label(self, node_labels)
+
+            print(f"Expected nodes: {expected_nodes}")
+            cluster_name = f"test-ray-cluster-li-{flavor[-5:]}"
+            queues = list_local_queues(namespace=self.namespace, flavors=[flavor])
+            queue_name = queues[0]["name"] if queues else None
+            print(f"Using flavor: {flavor}, Queue: {queue_name}")
+            cluster = Cluster(
+                ClusterConfiguration(
+                    namespace=self.namespace,
+                    name=cluster_name,
+                    num_workers=1,
+                    head_cpu_requests="500m",
+                    head_cpu_limits="500m",
+                    worker_cpu_requests="500m",
+                    worker_cpu_limits=1,
+                    worker_memory_requests=1,
+                    worker_memory_limits=4,
+                    image=ray_image,
+                    verify_tls=False,
+                    local_queue=queue_name,
+                )
+            )
+            cluster.up()
+            sleep(5)
+            node_name = get_pod_node(self, self.namespace, cluster_name)
+            print(f"Cluster {cluster_name}-{flavor} is running on node: {node_name}")
+            sleep(5)
+            assert (
+                node_name in expected_nodes
+            ), f"Node {node_name} is not in the expected nodes for flavor {flavor}."
+            cluster.down()


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[https://issues.redhat.com/browse/RHOAIENG-13430](https://issues.redhat.com/browse/RHOAIENG-13430)

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Added new e2e test for heterogenous cluster

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
[kueue](https://github.com/kubernetes-sigs/kueue) pull this and do:
`IMAGE_REGISTRY=quay.io/<username>/kueues make image-local-push deploy`

> Don't forget to change \<username\>

After building and installing new kueue test can be run by:

**Openshift**: `poetry run pytest -v -s ./tests/e2e -m 'openshift'`

**Local kind**: `poetry run pytest -v -s ./tests/e2e/heterogeneous_clusters_kind_test.py`

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->