### PR TITLE
Apply Workaround for SDK e2e tests to avoid SSL error

### DIFF
--- a/tests/e2e/local_interactive_sdk_oauth_test.py
+++ b/tests/e2e/local_interactive_sdk_oauth_test.py
@@ -1,7 +1,6 @@
 from codeflare_sdk import (
     Cluster,
     ClusterConfiguration,
-    TokenAuthentication,
     generate_cert,
 )
 
@@ -29,13 +28,6 @@ class TestRayLocalInteractiveOauth:
 
     def run_local_interactives(self):
         ray_image = get_ray_image()
-
-        auth = TokenAuthentication(
-            token=run_oc_command(["whoami", "--show-token=true"]),
-            server=run_oc_command(["whoami", "--show-server=true"]),
-            skip_tls=True,
-        )
-        auth.login()
 
         cluster_name = "test-ray-cluster-li"
 

--- a/tests/e2e/mnist_raycluster_sdk_oauth_test.py
+++ b/tests/e2e/mnist_raycluster_sdk_oauth_test.py
@@ -2,7 +2,7 @@ import requests
 
 from time import sleep
 
-from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication
+from codeflare_sdk import Cluster, ClusterConfiguration
 from codeflare_sdk.job import RayJobClient
 
 import pytest
@@ -29,13 +29,6 @@ class TestRayClusterSDKOauth:
 
     def run_mnist_raycluster_sdk_oauth(self):
         ray_image = get_ray_image()
-
-        auth = TokenAuthentication(
-            token=run_oc_command(["whoami", "--show-token=true"]),
-            server=run_oc_command(["whoami", "--show-server=true"]),
-            skip_tls=True,
-        )
-        auth.login()
 
         cluster = Cluster(
             ClusterConfiguration(

--- a/tests/upgrade/raycluster_sdk_upgrade_test.py
+++ b/tests/upgrade/raycluster_sdk_upgrade_test.py
@@ -1,7 +1,7 @@
 import requests
 from time import sleep
 
-from codeflare_sdk import Cluster, ClusterConfiguration, TokenAuthentication
+from codeflare_sdk import Cluster, ClusterConfiguration
 from codeflare_sdk.job import RayJobClient
 
 from tests.e2e.support import *
@@ -35,13 +35,6 @@ class TestMNISTRayClusterUp:
 
     def run_mnist_raycluster_sdk_oauth(self):
         ray_image = get_ray_image()
-
-        auth = TokenAuthentication(
-            token=run_oc_command(["whoami", "--show-token=true"]),
-            server=run_oc_command(["whoami", "--show-server=true"]),
-            skip_tls=True,
-        )
-        auth.login()
 
         cluster = Cluster(
             ClusterConfiguration(
@@ -83,12 +76,6 @@ class TestMNISTRayClusterUp:
 class TestMnistJobSubmit:
     def setup_method(self):
         initialize_kubernetes_client(self)
-        auth = TokenAuthentication(
-            token=run_oc_command(["whoami", "--show-token=true"]),
-            server=run_oc_command(["whoami", "--show-server=true"]),
-            skip_tls=True,
-        )
-        auth.login()
         self.namespace = namespace
         self.cluster = get_cluster("mnist", self.namespace)
         if not self.cluster:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
https://issues.redhat.com/browse/RHOAIENG-14785
Removed TokenAuthentication to avoid SSL error for 2.14 downstream testing
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->