### PR TITLE
fix: copy_demo_nbs function package path

### DIFF
--- a/src/codeflare_sdk/common/utils/demos.py
+++ b/src/codeflare_sdk/common/utils/demos.py
@@ -1,7 +1,7 @@
 import pathlib
 import shutil
 
-package_dir = pathlib.Path(__file__).parent.parent.resolve()
+package_dir = pathlib.Path(__file__).parent.parent.parent.resolve()
 demo_dir = f"{package_dir}/demo-notebooks"
 
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
# SDK
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Copy the `demo-notebooks` directory to `src/codeflare_sdk`
* Run `poetry build`
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
Run `copy_demo_nbs()` ensure that the demo notebooks spawn
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->