### PR TITLE
fix: get_cluster with job submission

### DIFF
--- a/src/codeflare_sdk/ray/cluster/cluster.py
+++ b/src/codeflare_sdk/ray/cluster/cluster.py
@@ -72,6 +72,7 @@ class Cluster:
         request.
         """
         self.config = config
+        self._job_submission_client = None
         if self.config is None:
             warnings.warn(
                 "Please provide a ClusterConfiguration to initialise the Cluster object"
@@ -80,7 +81,6 @@ class Cluster:
         else:
             self.resource_yaml = self.create_resource()
 
-        self._job_submission_client = None
         if is_notebook():
             cluster_up_down_buttons(self)
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[RHOAIENG-16073](https://issues.redhat.com/browse/RHOAIENG-16073)
# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Moved initialisation of `_job_submission_client`
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
* Create a Ray Cluster
* Use the `get_cluster` method on the created Ray Cluster
* Submit a Job via the job client
* `client = cluster.job_client`
* Ensure the client is initialised without error
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->