### PR TITLE
Add label to RayCluster if owned by AppWrapper

### DIFF
--- a/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
@@ -182,7 +182,7 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
 # Metadata related functions
 def get_metadata(cluster: "codeflare_sdk.ray.cluster.Cluster"):
     """
-    The get_metadata() function builds and returns a V1ObjectMeta Object using cluster configurtation parameters
+    The get_metadata() function builds and returns a V1ObjectMeta Object using cluster configuration parameters
     """
     object_meta = V1ObjectMeta(
         name=cluster.config.name,
@@ -206,6 +206,9 @@ def get_labels(cluster: "codeflare_sdk.ray.cluster.Cluster"):
     }
     if cluster.config.labels != {}:
         labels.update(cluster.config.labels)
+
+    if cluster.config.appwrapper is True:
+        labels.update({"resource.owner": "appwrapper"})
 
     if cluster.config.appwrapper is False:
         add_queue_label(cluster, labels)

--- a/tests/test_cluster_yamls/appwrapper/unit-test-all-params.yaml
+++ b/tests/test_cluster_yamls/appwrapper/unit-test-all-params.yaml
@@ -17,6 +17,7 @@ spec:
           controller-tools.k8s.io: '1.0'
           key1: value1
           key2: value2
+          resource.owner: appwrapper
         name: aw-all-params
         namespace: ns
       spec:

--- a/tests/test_cluster_yamls/kueue/aw_kueue.yaml
+++ b/tests/test_cluster_yamls/kueue/aw_kueue.yaml
@@ -13,6 +13,7 @@ spec:
       metadata:
         labels:
           controller-tools.k8s.io: '1.0'
+          resource.owner: appwrapper
         name: unit-test-aw-kueue
         namespace: ns
       spec:

--- a/tests/test_cluster_yamls/kueue/ray_cluster_kueue.yaml
+++ b/tests/test_cluster_yamls/kueue/ray_cluster_kueue.yaml
@@ -13,6 +13,7 @@ spec:
       metadata:
         labels:
           controller-tools.k8s.io: '1.0'
+          resource.owner: appwrapper
         name: unit-test-cluster-kueue
         namespace: ns
       spec:

--- a/tests/test_cluster_yamls/ray/default-appwrapper.yaml
+++ b/tests/test_cluster_yamls/ray/default-appwrapper.yaml
@@ -11,6 +11,7 @@ spec:
       metadata:
         labels:
           controller-tools.k8s.io: '1.0'
+          resource.owner: appwrapper
         name: default-appwrapper
         namespace: ns
       spec:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
Part of: https://issues.redhat.com/browse/RHOAIENG-14731 

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- When AppWrapper is True in ClusterConfiguration, a label is added to the RayCluster on creation.

This change is required to identify if the RayCluster is owned by an AppWrapper.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->