### PR TITLE
Add support for custom Volumes/Volume Mounts

### DIFF
--- a/docs/sphinx/user-docs/cluster-configuration.rst
+++ b/docs/sphinx/user-docs/cluster-configuration.rst
@@ -27,6 +27,8 @@ requirements for creating the Ray Cluster.
        # image="", # Optional Field
        labels={"exampleLabel": "example", "secondLabel": "example"},
        annotations={"key1":"value1", "key2":"value2"},
+       volumes=[], # See Custom Volumes/Volume Mounts
+       volume_mounts=[], # See Custom Volumes/Volume Mounts
    ))
 
 .. note::
@@ -48,6 +50,53 @@ apply additional labels to the RayCluster resource.
 
 After creating their ``cluster``, a user can call ``cluster.up()`` and
 ``cluster.down()`` to respectively create or remove the Ray Cluster.
+
+Custom Volumes/Volume Mounts
+----------------------------
+| To add custom Volumes and Volume Mounts to your Ray Cluster you need to create two lists ``volumes`` and ``volume_mounts``. The lists consist of ``V1Volume`` and ``V1VolumeMount`` objects respectively.
+| Populating these parameters will create Volumes and Volume Mounts for the head and each worker pod.
+
+.. code:: python
+
+  from kubernetes.client import V1Volume, V1VolumeMount, V1EmptyDirVolumeSource, V1ConfigMapVolumeSource, V1KeyToPath, V1SecretVolumeSource
+  # In this example we are using the Config Map, EmptyDir and Secret Volume types
+  volume_mounts_list = [
+      V1VolumeMount(
+          mount_path="/home/ray/test1",
+          name = "test"
+      ),
+      V1VolumeMount(
+          mount_path = "/home/ray/test2",
+          name = "test2",
+      ),
+      V1VolumeMount(
+          mount_path = "/home/ray/test3",
+          name = "test3",
+      )
+  ]
+
+  volumes_list = [
+      V1Volume(
+          name="test",
+          empty_dir=V1EmptyDirVolumeSource(size_limit="2Gi"),
+      ),
+      V1Volume(
+          name="test2",
+          config_map=V1ConfigMapVolumeSource(
+              name="test-config-map",
+              items=[V1KeyToPath(key="test", path="data.txt")]
+          )
+      ),
+      V1Volume(
+          name="test3",
+          secret=V1SecretVolumeSource(
+              secret_name="test-secret"
+          )
+      )
+  ]
+
+| For more information on creating Volumes and Volume Mounts with Python check out the Python Kubernetes docs (`Volumes <https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Volume.md>`__, `Volume Mounts <https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1VolumeMount.md>`__).
+| You can also find further information on Volumes and Volume Mounts by visiting the Kubernetes `documentation <https://kubernetes.io/docs/concepts/storage/volumes/>`__.
 
 Deprecating Parameters
 ----------------------

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -22,6 +22,7 @@ import pathlib
 import warnings
 from dataclasses import dataclass, field, fields
 from typing import Dict, List, Optional, Union, get_args, get_origin
+from kubernetes.client import V1Volume, V1VolumeMount
 
 dir = pathlib.Path(__file__).parent.parent.resolve()
 
@@ -91,6 +92,10 @@ class ClusterConfiguration:
             A boolean indicating whether to overwrite the default resource mapping.
         annotations:
             A dictionary of annotations to apply to the cluster.
+        volumes:
+            A list of V1Volume objects to add to the Cluster
+        volume_mounts:
+            A list of V1VolumeMount objects to add to the Cluster
     """
 
     name: str
@@ -129,6 +134,8 @@ class ClusterConfiguration:
     overwrite_default_resource_mapping: bool = False
     local_queue: Optional[str] = None
     annotations: Dict[str, str] = field(default_factory=dict)
+    volumes: list[V1Volume] = field(default_factory=list)
+    volume_mounts: list[V1VolumeMount] = field(default_factory=list)
 
     def __post_init__(self):
         if not self.verify_tls:

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -15,6 +15,7 @@
 from codeflare_sdk.common.utils.unit_test_support import (
     apply_template,
     createClusterWrongType,
+    get_example_extended_storage_opts,
     create_cluster_all_config_params,
     get_template_variables,
 )
@@ -64,6 +65,7 @@ def test_config_creation_all_parameters(mocker):
     expected_extended_resource_mapping = DEFAULT_RESOURCE_MAPPING
     expected_extended_resource_mapping.update({"example.com/gpu": "GPU"})
     expected_extended_resource_mapping["intel.com/gpu"] = "TPU"
+    volumes, volume_mounts = get_example_extended_storage_opts()
 
     cluster = create_cluster_all_config_params(mocker, "test-all-params", False)
     assert cluster.config.name == "test-all-params" and cluster.config.namespace == "ns"
@@ -98,6 +100,8 @@ def test_config_creation_all_parameters(mocker):
         "key1": "value1",
         "key2": "value2",
     }
+    assert cluster.config.volumes == volumes
+    assert cluster.config.volume_mounts == volume_mounts
 
     assert filecmp.cmp(
         f"{aw_dir}test-all-params.yaml",

--- a/tests/test_cluster_yamls/appwrapper/unit-test-all-params.yaml
+++ b/tests/test_cluster_yamls/appwrapper/unit-test-all-params.yaml
@@ -78,6 +78,12 @@ spec:
                     memory: 12G
                     nvidia.com/gpu: 1
                 volumeMounts:
+                - mountPath: /home/ray/test1
+                  name: test
+                - mountPath: /home/ray/test2
+                  name: test2
+                - mountPath: /home/ray/test2
+                  name: test3
                 - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                   name: odh-trusted-ca-cert
                   subPath: odh-trusted-ca-bundle.crt
@@ -94,6 +100,18 @@ spec:
               - name: secret1
               - name: secret2
               volumes:
+              - emptyDir:
+                  sizeLimit: 500Gi
+                name: test
+              - configMap:
+                  items:
+                  - key: test
+                    path: /home/ray/test2/data.txt
+                  name: config-map-test
+                name: test2
+              - name: test3
+                secret:
+                  secretName: test-secret
               - configMap:
                   items:
                   - key: ca-bundle.crt
@@ -146,6 +164,12 @@ spec:
                     memory: 12G
                     nvidia.com/gpu: 1
                 volumeMounts:
+                - mountPath: /home/ray/test1
+                  name: test
+                - mountPath: /home/ray/test2
+                  name: test2
+                - mountPath: /home/ray/test2
+                  name: test3
                 - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
                   name: odh-trusted-ca-cert
                   subPath: odh-trusted-ca-bundle.crt
@@ -162,6 +186,18 @@ spec:
               - name: secret1
               - name: secret2
               volumes:
+              - emptyDir:
+                  sizeLimit: 500Gi
+                name: test
+              - configMap:
+                  items:
+                  - key: test
+                    path: /home/ray/test2/data.txt
+                  name: config-map-test
+                name: test2
+              - name: test3
+                secret:
+                  secretName: test-secret
               - configMap:
                   items:
                   - key: ca-bundle.crt

--- a/tests/test_cluster_yamls/ray/unit-test-all-params.yaml
+++ b/tests/test_cluster_yamls/ray/unit-test-all-params.yaml
@@ -69,6 +69,12 @@ spec:
               memory: 12G
               nvidia.com/gpu: 1
           volumeMounts:
+          - mountPath: /home/ray/test1
+            name: test
+          - mountPath: /home/ray/test2
+            name: test2
+          - mountPath: /home/ray/test2
+            name: test3
           - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
             name: odh-trusted-ca-cert
             subPath: odh-trusted-ca-bundle.crt
@@ -85,6 +91,18 @@ spec:
         - name: secret1
         - name: secret2
         volumes:
+        - emptyDir:
+            sizeLimit: 500Gi
+          name: test
+        - configMap:
+            items:
+            - key: test
+              path: /home/ray/test2/data.txt
+            name: config-map-test
+          name: test2
+        - name: test3
+          secret:
+            secretName: test-secret
         - configMap:
             items:
             - key: ca-bundle.crt
@@ -137,6 +155,12 @@ spec:
               memory: 12G
               nvidia.com/gpu: 1
           volumeMounts:
+          - mountPath: /home/ray/test1
+            name: test
+          - mountPath: /home/ray/test2
+            name: test2
+          - mountPath: /home/ray/test2
+            name: test3
           - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
             name: odh-trusted-ca-cert
             subPath: odh-trusted-ca-bundle.crt
@@ -153,6 +177,18 @@ spec:
         - name: secret1
         - name: secret2
         volumes:
+        - emptyDir:
+            sizeLimit: 500Gi
+          name: test
+        - configMap:
+            items:
+            - key: test
+              path: /home/ray/test2/data.txt
+            name: config-map-test
+          name: test2
+        - name: test3
+          secret:
+            secretName: test-secret
         - configMap:
             items:
             - key: ca-bundle.crt


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Setup
### Notebook server ODH/RHOAI/Local
* Clone this repository with `git clone https://github.com/project-codeflare/codeflare-sdk.git`
* Checkout this PR's branch
* Run `poetry build` - install if needed (`pip install poetry`)
* Run `pip install --force-reinstall dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl` 
* Restart your notebook kernel
## Testing
The `volumes` and `volume_mounts` config parameters are both lists that take the `V1Volume` and `V1VolumeMount` objects respectively.
Below I have given some examples for testing purposes.
### Volumes/Volume Mounts configuration
```
from kubernetes.client import V1Volume, V1VolumeMount, V1EmptyDirVolumeSource, V1ConfigMapVolumeSource, V1KeyToPath, V1SecretVolumeSource
volume_mounts = [
    V1VolumeMount(
        mount_path="/home/ray/test1",
        name = "test"
    ),
    V1VolumeMount(
        mount_path = "/home/ray/test2",
        name = "test2",
    ),
    V1VolumeMount(
        mount_path = "/home/ray/test3",
        name = "test3",
    )
]

volumes = [
    V1Volume(
        name="test",
        empty_dir=V1EmptyDirVolumeSource(size_limit="2Gi"),
    ),
    V1Volume(
        name="test2",
        config_map=V1ConfigMapVolumeSource(
            name="test-config-map",
            items=[V1KeyToPath(key="test", path="data.txt")]
        )
    ),
    V1Volume(
        name="test3",
        secret=V1SecretVolumeSource(
            secret_name="test-secret"
    )
)
]
```
### ClusterConfiguration
```
cluster = Cluster(ClusterConfiguration(
    name='raytest', 
    head_cpu_requests='500m',
    head_cpu_limits='500m',
    head_memory_requests=2,
    head_memory_limits=2,
    head_extended_resource_requests={'nvidia.com/gpu':0}, 
    worker_extended_resource_requests={'nvidia.com/gpu':0},
    num_workers=2,
    worker_cpu_requests='250m',
    worker_cpu_limits=1,
    worker_memory_requests=4,
    worker_memory_limits=4,
    appwrapper=True,
    # image="", # Optional Field 
    write_to_file=True, # When enabled Ray Cluster yaml files are written to /HOME/.codeflare/resources 
    # local_queue="local-queue-name" # Specify the local queue manually
    volumes=volumes,
    volume_mounts=volume_mounts,
))
```
### Test Config Map
```
kind: ConfigMap
apiVersion: v1
metadata:
  name: test-config-map
  namespace: YOUR_NAMESPACE
immutable: false
data:
  test: pass
```
### Test Secret
* Create a secret on OpenShift by going to Workloads -> Secrets -> Create -> key/vaule secret
* Set the name to ` test-secret` 
* The key/value can be whatever you like

### Verify
The volumes & volume mounts should be added to your worker and head pods.
You can exec into your pod and check that the emptyDir, Config Map volume and Secret Volume were mounted correctly

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->