### PR TITLE
fix: cluster configuration validation for bool type

### DIFF
--- a/src/codeflare_sdk/common/utils/unit_test_support.py
+++ b/src/codeflare_sdk/common/utils/unit_test_support.py
@@ -55,7 +55,7 @@ def createClusterWrongType():
     config = ClusterConfiguration(
         name="unit-test-cluster",
         namespace="ns",
-        num_workers=2,
+        num_workers=True,
         worker_cpu_requests=[],
         worker_cpu_limits=4,
         worker_memory_requests=5,

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -242,13 +242,15 @@ class ClusterConfiguration:
 
     def _validate_types(self):
         """Validate the types of all fields in the ClusterConfiguration dataclass."""
+        errors = []
         for field_info in fields(self):
             value = getattr(self, field_info.name)
             expected_type = field_info.type
             if not self._is_type(value, expected_type):
-                raise TypeError(
-                    f"'{field_info.name}' should be of type {expected_type}"
-                )
+                errors.append(f"'{field_info.name}' should be of type {expected_type}.")
+
+        if errors:
+            raise TypeError("Type validation failed:\n" + "\n".join(errors))
 
     @staticmethod
     def _is_type(value, expected_type):
@@ -268,6 +270,10 @@ class ClusterConfiguration:
                 )
             if origin_type is tuple:
                 return all(check_type(elem, etype) for elem, etype in zip(value, args))
+            if expected_type is int:
+                return isinstance(value, int) and not isinstance(value, bool)
+            if expected_type is bool:
+                return isinstance(value, bool)
             return isinstance(value, expected_type)
 
         return check_type(value, expected_type)

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -108,8 +108,10 @@ def test_all_config_params_aw(mocker):
 
 
 def test_config_creation_wrong_type():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as error_info:
         createClusterWrongType()
+
+    assert len(str(error_info.value).splitlines()) == 4
 
 
 def test_cluster_config_deprecation_conversion(mocker):


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[https://issues.redhat.com/browse/RHOAIENG-11022](https://issues.redhat.com/browse/RHOAIENG-11022)

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Fixed cluster configuration validation for bool types, and changed so all type mismatches are reported simultaneously, rather than stopping at the first occurrence.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->