### PR TITLE
ci: remove intel from image updates in odh sync workflow

### DIFF
--- a/.github/workflows/odh-notebooks-sync.yml
+++ b/.github/workflows/odh-notebooks-sync.yml
@@ -56,10 +56,8 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pipenv'
 
-      # Sync fails with pipenv 2024.1.0 (current latest version)
-      # TODO: We should retry with later versions of pipenv once they are available.
       - name: Install pipenv and pip-versions
-        run: pip install pipenv==2024.0.3 pip-versions
+        run: pip install pipenv==2024.4.0 pip-versions
 
       - name: Update Pipfiles in accordance with Codeflare-SDK latest release
         run: |
@@ -74,7 +72,7 @@ jobs:
             # replace existing version of cf-sdk with new version in Pipfile
             sed -i "s/codeflare-sdk = .*$/codeflare-sdk = \"~=$CODEFLARE_RELEASE_VERSION\"/g" Pipfile
             # Lock dependencies, ensuring pre-release are included and clear previous state
-            if ! pipenv lock --pre --clear ; then
+            if ! pipenv lock --verbose --pre --clear ; then
               echo "Failed to lock dependencies"
               exit 1
             fi
@@ -98,7 +96,8 @@ jobs:
             echo "Version ${CODEFLARE_RELEASE_VERSION} is available for $package_name"
             # list all Pipfile paths having Codeflare-SDK listed
             # Extracting only directories from file paths, excluding a `.gitworkflow` and `.git` directory
-            directories+=($(grep --exclude-dir=.git --exclude-dir=.github --include="Pipfile*" -rl "${package_name} = \"~=.*\"" | xargs dirname | sort | uniq))
+            # Extracting Intel directories as they are not supported in RHOAI
+            directories+=($(grep --exclude-dir=.git --exclude-dir=.github --exclude-dir=intel --exclude-dir=jupyter/intel --include="Pipfile*" -rl "${package_name} = \"~=.*\"" | xargs dirname | sort | uniq))
             counter=0
             total=${#directories[@]}
             for dir in "${directories[@]}"; do


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Due to failing ODH Sync workflow it is best that we remove the intel images from our updates as they are not supported see [here](https://redhat-internal.slack.com/archives/C060A5FJEAD/p1736501997555039) for more details
* Updated pipenv to `2024.4.0`
* Added verbose flag to `pipenv lock`
* Excluded intel directories for notebooks repo
# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->