### PR TITLE
Enable persistent Ray cluster state via external Redis GCS fault tolerance

### DIFF
--- a/docs/sphinx/user-docs/cluster-configuration.rst
+++ b/docs/sphinx/user-docs/cluster-configuration.rst
@@ -97,6 +97,48 @@ Custom Volumes/Volume Mounts
 | For more information on creating Volumes and Volume Mounts with Python check out the Python Kubernetes docs (`Volumes <https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1Volume.md>`__, `Volume Mounts <https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1VolumeMount.md>`__).
 | You can also find further information on Volumes and Volume Mounts by visiting the Kubernetes `documentation <https://kubernetes.io/docs/concepts/storage/volumes/>`__.
 
+GCS Fault Tolerance
+------------------
+By default, the state of the Ray cluster is transient to the head Pod. Whatever triggers a restart of the head Pod results in losing that state, including Ray Cluster history. To make Ray cluster state persistent you can enable Global Control Service (GCS) fault tolerance with an external Redis storage.
+
+To configure GCS fault tolerance you need to set the following parameters:
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Parameter
+     - Description
+   * - ``enable_gcs_ft``
+     - Boolean to enable GCS fault tolerance
+   * - ``redis_address``
+     - Address of the external Redis service, ex: "redis:6379"
+   * - ``redis_password_secret``
+     - Dictionary with 'name' and 'key' fields specifying the Kubernetes secret for Redis password
+   * - ``external_storage_namespace``
+     - Custom storage namespace for GCS fault tolerance (by default, KubeRay sets it to the RayCluster's UID)
+
+Example configuration:
+
+.. code:: python
+
+   from codeflare_sdk import Cluster, ClusterConfiguration
+
+   cluster = Cluster(ClusterConfiguration(
+       name='ray-cluster-with-persistence',
+       num_workers=2,
+       enable_gcs_ft=True,
+       redis_address="redis:6379",
+       redis_password_secret={
+           "name": "redis-password-secret",
+           "key": "password"
+       },
+       # external_storage_namespace="my-custom-namespace" # Optional: Custom namespace for GCS data in Redis
+   ))
+
+.. note::
+   You need to have a Redis instance deployed in your Kubernetes cluster before using this feature.
+
 Deprecating Parameters
 ----------------------
 

--- a/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
@@ -169,6 +169,31 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
         },
     }
 
+    if cluster.config.enable_gcs_ft:
+        if not cluster.config.redis_address:
+            raise ValueError(
+                "redis_address must be provided when enable_gcs_ft is True"
+            )
+
+        gcs_ft_options = {"redisAddress": cluster.config.redis_address}
+
+        if cluster.config.external_storage_namespace:
+            gcs_ft_options[
+                "externalStorageNamespace"
+            ] = cluster.config.external_storage_namespace
+
+        if cluster.config.redis_password_secret:
+            gcs_ft_options["redisPassword"] = {
+                "valueFrom": {
+                    "secretKeyRef": {
+                        "name": cluster.config.redis_password_secret["name"],
+                        "key": cluster.config.redis_password_secret["key"],
+                    }
+                }
+            }
+
+        resource["spec"]["gcsFaultToleranceOptions"] = gcs_ft_options
+
     config_check()
     k8s_client = get_api_client() or client.ApiClient()
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->
[RHOAIENG-11115](https://issues.redhat.com/browse/RHOAIENG-11115)

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Provided Ray cluster head pod persistency through GCS fault tolerance.
Added new config options: `enable_gcs_ft`, `redis_address`, `redis_password_secret` and `external_storage_namespace`
Added unit tests to cover gcs fault tolerance

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- Provision a cluster
- Deploy Redis in your cluster ( you can use this [example](https://github.com/ray-project/kuberay/blob/master/ray-operator/config/samples/ray-cluster.external-redis.yaml))
- Deploy [KubeRay](https://docs.ray.io/en/latest/cluster/kubernetes/getting-started/raycluster-quick-start.html#step-2-deploy-a-kuberay-operator) operator (1.3.0 or newer, RHOAI currently provides an older version)
- Create RayCluster with GCS fault tolerance enabled, for example:
```
cluster = Cluster(ClusterConfiguration(
        name='raycluster',
        head_cpu_requests='500m',
        head_cpu_limits='500m',
        head_memory_requests=2,
        head_memory_limits=2,
        num_workers=1,
        worker_cpu_requests='250m',
        worker_cpu_limits=1,
        worker_memory_requests=4,
        worker_memory_limits=4,
        enable_gcs_ft=True,
        redis_address="redis:6379",
        redis_password_secret={
            "name": "redis-password-secret",
            "key": "password"
        }
    ))
```
- Make sure all pods are running
- Create a [detached actor](https://docs.ray.io/en/latest/cluster/kubernetes/user-guides/kuberay-gcs-ft.html#step-5-create-a-detached-actor) 
- Check if the actor is visible - `ray list actors` from RayCluster head pod
- Restart the head pod
- Run `ray list actors` - you should see previously created actor

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->