### PR TITLE
fix(RHOAIENG-25120): remove kueue as mandatory in RayCluster

### DIFF
--- a/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
@@ -488,9 +488,11 @@ def add_queue_label(cluster: "codeflare_sdk.ray.cluster.Cluster", labels: dict):
     if lq_name == None:
         return
     elif not local_queue_exists(cluster):
-        raise ValueError(
+        # ValueError removed to pass validation to validating admission policy
+        print(
             "local_queue provided does not exist or is not in this namespace. Please provide the correct local_queue name in Cluster Configuration"
         )
+        return
     labels.update({"kueue.x-k8s.io/queue-name": lq_name})
 
 

--- a/src/codeflare_sdk/ray/cluster/cluster.py
+++ b/src/codeflare_sdk/ray/cluster/cluster.py
@@ -183,6 +183,14 @@ class Cluster:
                     f"Ray Cluster: '{self.config.name}' has successfully been created"
                 )
         except Exception as e:  # pragma: no cover
+            if e.status == 422:
+                print(
+                    "WARNING: RayCluster creation rejected due to invalid Kueue configuration. Please contact your administrator."
+                )
+            else:
+                print(
+                    "WARNING: Failed to create RayCluster due to unexpected error. Please contact your administrator."
+                )
             return _kube_api_error_handling(e)
 
     # Applies a new cluster with the provided or default spec
@@ -231,6 +239,14 @@ class Cluster:
         except AttributeError as e:
             raise RuntimeError(f"Failed to initialize DynamicClient: {e}")
         except Exception as e:  # pragma: no cover
+            if e.status == 422:
+                print(
+                    "WARNING: RayCluster creation rejected due to invalid Kueue configuration. Please contact your administrator."
+                )
+            else:
+                print(
+                    "WARNING: Failed to create RayCluster due to unexpected error. Please contact your administrator."
+                )
             return _kube_api_error_handling(e)
 
     def _throw_for_no_raycluster(self):


### PR DESCRIPTION
# Issue link
[Jira Link](https://issues.redhat.com/browse/RHOAIENG-25120)

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
* With appropriate Kueue config (a cluster queue and local queue CR on your cluster) create a RayCluster with an invalid label. This should return the VAP error. In this instance, it's not our code blocking the creation but the VAP itself.
* With the above but leaving local queue blank or set to an existing one, resource should create without issue.
* With Kueue removed, passing an invalid local_queue will result in a message to user but no hard error.
* With Kueue removed, RayCluster creation works as intended, no hard errors or blockages.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->