### PR TITLE
task(RHOAIENG-26192): Removed dep fields head_gpus + num_gpus

### DIFF
--- a/docs/sphinx/user-docs/cluster-configuration.rst
+++ b/docs/sphinx/user-docs/cluster-configuration.rst
@@ -180,7 +180,3 @@ deprecated.
      - ``worker_memory_requests``
    * - ``max_memory``
      - ``worker_memory_limits``
-   * - ``head_gpus``
-     - ``head_extended_resource_requests``
-   * - ``num_gpus``
-     - ``worker_extended_resource_requests``

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -54,8 +54,6 @@ class ClusterConfiguration:
             The number of CPUs to allocate to the head node.
         head_memory:
             The amount of memory to allocate to the head node.
-        head_gpus:
-            The number of GPUs to allocate to the head node. (Deprecated, use head_extended_resource_requests)
         head_extended_resource_requests:
             A dictionary of extended resource requests for the head node. ex: {"nvidia.com/gpu": 1}
         head_tolerations:
@@ -70,8 +68,6 @@ class ClusterConfiguration:
             The minimum amount of memory to allocate to each worker.
         max_memory:
             The maximum amount of memory to allocate to each worker.
-        num_gpus:
-            The number of GPUs to allocate to each worker. (Deprecated, use worker_extended_resource_requests)
         worker_tolerations:
             List of tolerations for worker nodes.
         appwrapper:
@@ -120,7 +116,6 @@ class ClusterConfiguration:
     head_memory_requests: Union[int, str] = 8
     head_memory_limits: Union[int, str] = 8
     head_memory: Optional[Union[int, str]] = None  # Deprecating
-    head_gpus: Optional[int] = None  # Deprecating
     head_extended_resource_requests: Dict[str, Union[str, int]] = field(
         default_factory=dict
     )
@@ -134,7 +129,6 @@ class ClusterConfiguration:
     worker_memory_limits: Union[int, str] = 2
     min_memory: Optional[Union[int, str]] = None  # Deprecating
     max_memory: Optional[Union[int, str]] = None  # Deprecating
-    num_gpus: Optional[int] = None  # Deprecating
     worker_tolerations: Optional[List[V1Toleration]] = None
     appwrapper: bool = False
     envs: Dict[str, str] = field(default_factory=dict)
@@ -195,7 +189,6 @@ class ClusterConfiguration:
         self._memory_to_string()
         self._str_mem_no_unit_add_GB()
         self._cpu_to_resource()
-        self._gpu_to_resource()
         self._combine_extended_resource_mapping()
         self._validate_extended_resource_requests(self.head_extended_resource_requests)
         self._validate_extended_resource_requests(
@@ -226,26 +219,6 @@ class ClusterConfiguration:
                 raise ValueError(
                     f"extended resource '{k}' not found in extended_resource_mapping, available resources are {list(self.extended_resource_mapping.keys())}, to add more supported resources use extended_resource_mapping. i.e. extended_resource_mapping = {{'{k}': 'FOO_BAR'}}"
                 )
-
-    def _gpu_to_resource(self):
-        if self.head_gpus:
-            warnings.warn(
-                f"head_gpus is being deprecated, replacing with head_extended_resource_requests['nvidia.com/gpu'] = {self.head_gpus}"
-            )
-            if "nvidia.com/gpu" in self.head_extended_resource_requests:
-                raise ValueError(
-                    "nvidia.com/gpu already exists in head_extended_resource_requests"
-                )
-            self.head_extended_resource_requests["nvidia.com/gpu"] = self.head_gpus
-        if self.num_gpus:
-            warnings.warn(
-                f"num_gpus is being deprecated, replacing with worker_extended_resource_requests['nvidia.com/gpu'] = {self.num_gpus}"
-            )
-            if "nvidia.com/gpu" in self.worker_extended_resource_requests:
-                raise ValueError(
-                    "nvidia.com/gpu already exists in worker_extended_resource_requests"
-                )
-            self.worker_extended_resource_requests["nvidia.com/gpu"] = self.num_gpus
 
     def _str_mem_no_unit_add_GB(self):
         if isinstance(self.head_memory, str) and self.head_memory.isdecimal():

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -139,8 +139,6 @@ def test_config_creation_wrong_type():
 def test_cluster_config_deprecation_conversion(mocker):
     config = ClusterConfiguration(
         name="test",
-        num_gpus=2,
-        head_gpus=1,
         head_cpus=3,
         head_memory=16,
         min_memory=3,
@@ -152,8 +150,6 @@ def test_cluster_config_deprecation_conversion(mocker):
     assert config.head_cpu_limits == 3
     assert config.head_memory_requests == "16G"
     assert config.head_memory_limits == "16G"
-    assert config.worker_extended_resource_requests == {"nvidia.com/gpu": 2}
-    assert config.head_extended_resource_requests == {"nvidia.com/gpu": 1}
     assert config.worker_memory_requests == "3G"
     assert config.worker_memory_limits == "4G"
     assert config.worker_cpu_requests == 1


### PR DESCRIPTION
# Issue link
[Jira Link](https://issues.redhat.com/browse/RHOAIENG-26192)

# What changes have been made
`head_gpus` and `num_gpus` have reached the end of their deprecation notice period. These values and related logic have been removed as per the Jira.

# Verification steps
1. Build a version of the CodeFlare SDK based on this PR.
2. Pip install it in a Jupyter Notebook running in RHOAI.
3. Attempt to use the deprecated values when defining a cluster.
4. This should now throw an unexpected keyword argument versus previous logic.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->