### PR TITLE
task(RHOAIENG-28599): Removed dep fields min + max cpus + memory

### DIFF
--- a/docs/sphinx/user-docs/cluster-configuration.rst
+++ b/docs/sphinx/user-docs/cluster-configuration.rst
@@ -172,11 +172,3 @@ deprecated.
      - ``head_cpu_requests``, ``head_cpu_limits``
    * - ``head_memory``
      - ``head_memory_requests``, ``head_memory_limits``
-   * - ``min_cpus``
-     - ``worker_cpu_requests``
-   * - ``max_cpus``
-     - ``worker_cpu_limits``
-   * - ``min_memory``
-     - ``worker_memory_requests``
-   * - ``max_memory``
-     - ``worker_memory_limits``

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -58,16 +58,8 @@ class ClusterConfiguration:
             A dictionary of extended resource requests for the head node. ex: {"nvidia.com/gpu": 1}
         head_tolerations:
             List of tolerations for head nodes.
-        min_cpus:
-            The minimum number of CPUs to allocate to each worker.
-        max_cpus:
-            The maximum number of CPUs to allocate to each worker.
         num_workers:
             The number of workers to create.
-        min_memory:
-            The minimum amount of memory to allocate to each worker.
-        max_memory:
-            The maximum amount of memory to allocate to each worker.
         worker_tolerations:
             List of tolerations for worker nodes.
         appwrapper:
@@ -122,13 +114,9 @@ class ClusterConfiguration:
     head_tolerations: Optional[List[V1Toleration]] = None
     worker_cpu_requests: Union[int, str] = 1
     worker_cpu_limits: Union[int, str] = 1
-    min_cpus: Optional[Union[int, str]] = None  # Deprecating
-    max_cpus: Optional[Union[int, str]] = None  # Deprecating
     num_workers: int = 1
     worker_memory_requests: Union[int, str] = 2
     worker_memory_limits: Union[int, str] = 2
-    min_memory: Optional[Union[int, str]] = None  # Deprecating
-    max_memory: Optional[Union[int, str]] = None  # Deprecating
     worker_tolerations: Optional[List[V1Toleration]] = None
     appwrapper: bool = False
     envs: Dict[str, str] = field(default_factory=dict)
@@ -250,12 +238,6 @@ class ClusterConfiguration:
                 "head_cpus is being deprecated, use head_cpu_requests and head_cpu_limits"
             )
             self.head_cpu_requests = self.head_cpu_limits = self.head_cpus
-        if self.min_cpus:
-            warnings.warn("min_cpus is being deprecated, use worker_cpu_requests")
-            self.worker_cpu_requests = self.min_cpus
-        if self.max_cpus:
-            warnings.warn("max_cpus is being deprecated, use worker_cpu_limits")
-            self.worker_cpu_limits = self.max_cpus
 
     def _memory_to_resource(self):
         if self.head_memory:
@@ -263,12 +245,6 @@ class ClusterConfiguration:
                 "head_memory is being deprecated, use head_memory_requests and head_memory_limits"
             )
             self.head_memory_requests = self.head_memory_limits = self.head_memory
-        if self.min_memory:
-            warnings.warn("min_memory is being deprecated, use worker_memory_requests")
-            self.worker_memory_requests = f"{self.min_memory}G"
-        if self.max_memory:
-            warnings.warn("max_memory is being deprecated, use worker_memory_limits")
-            self.worker_memory_limits = f"{self.max_memory}G"
 
     def _validate_types(self):
         """Validate the types of all fields in the ClusterConfiguration dataclass."""

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -141,19 +141,15 @@ def test_cluster_config_deprecation_conversion(mocker):
         name="test",
         head_cpus=3,
         head_memory=16,
-        min_memory=3,
-        max_memory=4,
-        min_cpus=1,
-        max_cpus=2,
     )
     assert config.head_cpu_requests == 3
     assert config.head_cpu_limits == 3
     assert config.head_memory_requests == "16G"
     assert config.head_memory_limits == "16G"
-    assert config.worker_memory_requests == "3G"
-    assert config.worker_memory_limits == "4G"
+    assert config.worker_memory_requests == "2G"
+    assert config.worker_memory_limits == "2G"
     assert config.worker_cpu_requests == 1
-    assert config.worker_cpu_limits == 2
+    assert config.worker_cpu_limits == 1
 
 
 def test_gcs_fault_tolerance_config_validation():


### PR DESCRIPTION
# Issue link
[Jira Link
](https://issues.redhat.com/browse/RHOAIENG-28599)
# What changes have been made
Removal of deprecated fields as they've reached the end of dep notice period:

* `max_memory`
* `min_memory`
* `max_cpus`
* `min_cpus`

# Verification steps
* Build a whl file from this branch.
* Pip install it within a jupyter notebook.
* Create a cluster configuration containing any of the deprecated fields.
* Attempting to execute the initialisation cell should throw an `unexpected keyword argument` error.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->