### PR TITLE
task(RHOAIENG-30478)Remove Deprecated Params from CodeFlare SDK (head_cpus & head_memory)

### DIFF
--- a/docs/sphinx/user-docs/cluster-configuration.rst
+++ b/docs/sphinx/user-docs/cluster-configuration.rst
@@ -155,20 +155,3 @@ Example configuration:
 
 .. note::
    You need to have a Redis instance deployed in your Kubernetes cluster before using this feature.
-
-Deprecating Parameters
-----------------------
-
-The following parameters of the ``ClusterConfiguration`` are being
-deprecated.
-
-.. list-table::
-   :header-rows: 1
-   :widths: auto
-
-   * - Deprecated Parameter
-     - Replaced By
-   * - ``head_cpus``
-     - ``head_cpu_requests``, ``head_cpu_limits``
-   * - ``head_memory``
-     - ``head_memory_requests``, ``head_memory_limits``

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -50,10 +50,6 @@ class ClusterConfiguration:
             The name of the cluster.
         namespace:
             The namespace in which the cluster should be created.
-        head_cpus:
-            The number of CPUs to allocate to the head node.
-        head_memory:
-            The amount of memory to allocate to the head node.
         head_extended_resource_requests:
             A dictionary of extended resource requests for the head node. ex: {"nvidia.com/gpu": 1}
         head_tolerations:
@@ -104,10 +100,8 @@ class ClusterConfiguration:
     namespace: Optional[str] = None
     head_cpu_requests: Union[int, str] = 2
     head_cpu_limits: Union[int, str] = 2
-    head_cpus: Optional[Union[int, str]] = None  # Deprecating
     head_memory_requests: Union[int, str] = 8
     head_memory_limits: Union[int, str] = 8
-    head_memory: Optional[Union[int, str]] = None  # Deprecating
     head_extended_resource_requests: Dict[str, Union[str, int]] = field(
         default_factory=dict
     )
@@ -173,10 +167,8 @@ class ClusterConfiguration:
                 )
 
         self._validate_types()
-        self._memory_to_resource()
         self._memory_to_string()
         self._str_mem_no_unit_add_GB()
-        self._cpu_to_resource()
         self._combine_extended_resource_mapping()
         self._validate_extended_resource_requests(self.head_extended_resource_requests)
         self._validate_extended_resource_requests(
@@ -209,8 +201,6 @@ class ClusterConfiguration:
                 )
 
     def _str_mem_no_unit_add_GB(self):
-        if isinstance(self.head_memory, str) and self.head_memory.isdecimal():
-            self.head_memory = f"{self.head_memory}G"
         if (
             isinstance(self.worker_memory_requests, str)
             and self.worker_memory_requests.isdecimal()
@@ -231,20 +221,6 @@ class ClusterConfiguration:
             self.worker_memory_requests = f"{self.worker_memory_requests}G"
         if isinstance(self.worker_memory_limits, int):
             self.worker_memory_limits = f"{self.worker_memory_limits}G"
-
-    def _cpu_to_resource(self):
-        if self.head_cpus:
-            warnings.warn(
-                "head_cpus is being deprecated, use head_cpu_requests and head_cpu_limits"
-            )
-            self.head_cpu_requests = self.head_cpu_limits = self.head_cpus
-
-    def _memory_to_resource(self):
-        if self.head_memory:
-            warnings.warn(
-                "head_memory is being deprecated, use head_memory_requests and head_memory_limits"
-            )
-            self.head_memory_requests = self.head_memory_limits = self.head_memory
 
     def _validate_types(self):
         """Validate the types of all fields in the ClusterConfiguration dataclass."""

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -135,23 +135,6 @@ def test_config_creation_wrong_type():
     assert len(str(error_info.value).splitlines()) == 4
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
-def test_cluster_config_deprecation_conversion(mocker):
-    config = ClusterConfiguration(
-        name="test",
-        head_cpus=3,
-        head_memory=16,
-    )
-    assert config.head_cpu_requests == 3
-    assert config.head_cpu_limits == 3
-    assert config.head_memory_requests == "16G"
-    assert config.head_memory_limits == "16G"
-    assert config.worker_memory_requests == "2G"
-    assert config.worker_memory_limits == "2G"
-    assert config.worker_cpu_requests == 1
-    assert config.worker_cpu_limits == 1
-
-
 def test_gcs_fault_tolerance_config_validation():
     config = ClusterConfiguration(
         name="test",


### PR DESCRIPTION
# Issue link
[jira](https://issues.redhat.com/browse/RHOAIENG-30478)

# What changes have been made
- Removed deprecated parameters: head_cpus & head_memory & associated deprecation logic& test file
- Removed deprecated parameter references from docstrings

# Verification steps
Run demo-notebook files, check that:
- Existing code using new parameters (`head_cpu_requests`, etc.) continues to work
- Code using deprecated parameters (`head_cpus`, `head_memory`) fails with clear error messages

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<img width="1014" height="454" alt="Screenshot 2025-08-25 at 16 33 29" src="https://github.com/user-attachments/assets/b2518818-8673-4277-a0f2-c81dced0d0db" />
