### PR TITLE
task(RHOAIENG-33045): Update Runtime image SHAs for PY312

### DIFF
--- a/.github/workflows/e2e_tests.yaml
+++ b/.github/workflows/e2e_tests.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Set up specific Python version
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip' # caching pip dependencies
 
       - name: Setup NVidia GPU environment for KinD

--- a/demo-notebooks/additional-demos/hf_interactive.ipynb
+++ b/demo-notebooks/additional-demos/hf_interactive.ipynb
@@ -70,7 +70,8 @@
     "\n",
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
-    "- For Python 3.11: 'quay.io/modh/ray:2.35.0-py311-cu121'\n",
+    "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/additional-demos/local_interactive.ipynb
+++ b/demo-notebooks/additional-demos/local_interactive.ipynb
@@ -38,6 +38,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/additional-demos/ray_job_client.ipynb
+++ b/demo-notebooks/additional-demos/ray_job_client.ipynb
@@ -44,6 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/0_basic_ray.ipynb
@@ -50,6 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
@@ -44,6 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/2_basic_interactive.ipynb
@@ -47,6 +47,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/3_widget_example.ipynb
+++ b/demo-notebooks/guided-demos/3_widget_example.ipynb
@@ -50,6 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
@@ -50,6 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
@@ -44,6 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
@@ -47,6 +47,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
@@ -50,6 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
@@ -44,6 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
@@ -47,6 +47,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/src/codeflare_sdk/common/utils/constants.py
+++ b/src/codeflare_sdk/common/utils/constants.py
@@ -1,3 +1,14 @@
 RAY_VERSION = "2.47.1"
-# Below references ray:2.47.1-py311-cu121
-CUDA_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e"
+"""
+The below are used to define the default runtime image for the Ray Cluster.
+* For python 3.11:ray:2.47.1-py311-cu121
+* For python 3.12:ray:2.47.1-py312-cu121
+"""
+CUDA_PY311_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e"
+CUDA_PY312_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:23860dfe2e47bb69709b3883b08fd1a4d836ce02eaf8d0afeeafe6986d0fc8fb"
+
+# Centralized image selection
+SUPPORTED_PYTHON_VERSIONS = {
+    "3.11": CUDA_PY311_RUNTIME_IMAGE,
+    "3.12": CUDA_PY312_RUNTIME_IMAGE,
+}

--- a/src/codeflare_sdk/common/utils/unit_test_support.py
+++ b/src/codeflare_sdk/common/utils/unit_test_support.py
@@ -15,6 +15,7 @@
 import string
 import sys
 from codeflare_sdk.common.utils import constants
+from codeflare_sdk.common.utils.utils import get_ray_image_for_python_version
 from codeflare_sdk.ray.cluster.cluster import (
     Cluster,
     ClusterConfiguration,
@@ -69,7 +70,7 @@ def create_cluster_wrong_type():
         worker_extended_resource_requests={"nvidia.com/gpu": 7},
         appwrapper=True,
         image_pull_secrets=["unit-test-pull-secret"],
-        image=constants.CUDA_RUNTIME_IMAGE,
+        image=constants.CUDA_PY312_RUNTIME_IMAGE,
         write_to_file=True,
         labels={1: 1},
     )
@@ -294,8 +295,8 @@ def apply_template(yaml_file_path, variables):
 
 
 def get_expected_image():
-    # TODO: Select image based on Python version
-    return constants.CUDA_RUNTIME_IMAGE
+    # Use centralized image selection logic (fallback to 3.12 for test consistency)
+    return get_ray_image_for_python_version(warn_on_unsupported=True)
 
 
 def get_template_variables():

--- a/src/codeflare_sdk/common/utils/utils.py
+++ b/src/codeflare_sdk/common/utils/utils.py
@@ -1,0 +1,46 @@
+# Copyright 2025 IBM, Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+
+from codeflare_sdk.common.utils.constants import (
+    SUPPORTED_PYTHON_VERSIONS,
+    CUDA_PY312_RUNTIME_IMAGE,
+)
+
+
+def get_ray_image_for_python_version(python_version=None, warn_on_unsupported=True):
+    """
+    Get the appropriate Ray image for a given Python version.
+    If no version is provided, uses the current runtime Python version.
+    This prevents us needing to hard code image versions for tests.
+
+    Args:
+        python_version: Python version string (e.g. "3.11"). If None, detects current version.
+        warn_on_unsupported: If True, warns and returns None for unsupported versions.
+                           If False, silently falls back to Python 3.12 image.
+    """
+    if python_version is None:
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    if python_version in SUPPORTED_PYTHON_VERSIONS:
+        return SUPPORTED_PYTHON_VERSIONS[python_version]
+    elif warn_on_unsupported:
+        import warnings
+
+        warnings.warn(
+            f"No default Ray image defined for {python_version}. Please provide your own image or use one of the following python versions: {', '.join(SUPPORTED_PYTHON_VERSIONS.keys())}."
+        )
+        return None
+    else:
+        return CUDA_PY312_RUNTIME_IMAGE

--- a/src/codeflare_sdk/ray/cluster/test_build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/test_build_ray_cluster.py
@@ -43,6 +43,7 @@ def test_update_image_without_supported_python_version(mocker):
         "codeflare_sdk.ray.cluster.build_ray_cluster.SUPPORTED_PYTHON_VERSIONS",
         {
             "3.11": "ray-py3.11",
+            "3.12": "ray-py3.12",
         },
     )
 
@@ -60,7 +61,7 @@ def test_update_image_without_supported_python_version(mocker):
 
     # Assert that the warning was called with the expected message
     warn_mock.assert_called_once_with(
-        "No default Ray image defined for 3.8. Please provide your own image or use one of the following python versions: 3.11."
+        "No default Ray image defined for 3.8. Please provide your own image or use one of the following python versions: 3.11, 3.12."
     )
 
     # Assert that no image was set since the Python version is not supported

--- a/tests/e2e/local_interactive_sdk_kind_test.py
+++ b/tests/e2e/local_interactive_sdk_kind_test.py
@@ -115,7 +115,9 @@ class TestRayLocalInteractiveKind:
 
             ref = heavy_calculation.remote(3000)
             result = ray.get(ref)
-            assert result == 1789.4644387076714
+            assert (
+                result == 1789.4644387076728
+            )  # Updated result after moving to Python 3.12 (0.0000000000008% difference to old assertion)
             ray.cancel(ref)
             ray.shutdown()
 

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -8,6 +8,7 @@ from codeflare_sdk.common.kubernetes_cluster.kube_api_helpers import (
     _kube_api_error_handling,
 )
 from codeflare_sdk.common.utils import constants
+from codeflare_sdk.common.utils.utils import get_ray_image_for_python_version
 
 
 def get_ray_cluster(cluster_name, namespace):
@@ -27,7 +28,10 @@ def get_ray_cluster(cluster_name, namespace):
 
 
 def get_ray_image():
-    return os.getenv("RAY_IMAGE", constants.CUDA_RUNTIME_IMAGE)
+    return os.getenv(
+        "RAY_IMAGE",
+        get_ray_image_for_python_version(warn_on_unsupported=False),
+    )
 
 
 def get_setup_env_variables(**kwargs):


### PR DESCRIPTION
# Issue link
[Jira Link](https://issues.redhat.com/browse/RHOAIENG-33045)

# What changes have been made
Updated CodeFlare SDK runtime image defaults to include the new Python 3.12 image. This has also been updated in the demo notebooks where referenced.

Additionally, I've moved our supported versions logic to `constants.py` as I feel this is a more intuitively central location for this. Similarly, a new `utils.py` file extracts the correct runtime image version to pull in place of the less central existing logic.

# Verification steps
* Checkout this branch.
* Build the `whl` file by running `poetry build`.
* Open any demo notebook and set the kernel to a Python 3.12 version.
* Install this version of the SDK by running `pip install <path_to_your_whl> --force-reinstall`
* Restart the kernel.
* Create a Ray Cluster.
* Check the head pod spec for the image tag or log in to its terminal and run `python3 --version` to verify that it is using Python 3.12.9.
* Repeat the above with a kernel set to Python 3.11 to verify that the old image is also used as needed.

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->