### PR TITLE
task(RHOAIENG-33492): Bump Ray image to CUDA 12.8

### DIFF
--- a/demo-notebooks/additional-demos/hf_interactive.ipynb
+++ b/demo-notebooks/additional-demos/hf_interactive.ipynb
@@ -71,7 +71,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/additional-demos/local_interactive.ipynb
+++ b/demo-notebooks/additional-demos/local_interactive.ipynb
@@ -38,7 +38,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/additional-demos/ray_job_client.ipynb
+++ b/demo-notebooks/additional-demos/ray_job_client.ipynb
@@ -44,7 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/0_basic_ray.ipynb
@@ -50,7 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/1_cluster_job_client.ipynb
@@ -44,7 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/2_basic_interactive.ipynb
@@ -47,7 +47,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/3_widget_example.ipynb
+++ b/demo-notebooks/guided-demos/3_widget_example.ipynb
@@ -50,7 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
@@ -50,7 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/1_cluster_job_client.ipynb
@@ -44,7 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/2_basic_interactive.ipynb
@@ -47,7 +47,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
@@ -50,7 +50,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/1_cluster_job_client.ipynb
@@ -44,7 +44,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/2_basic_interactive.ipynb
@@ -47,7 +47,7 @@
     "NOTE: The default images used by the CodeFlare SDK for creating a RayCluster resource depend on the installed Python version:\n",
     "\n",
     "- For Python 3.11: 'quay.io/modh/ray:2.47.1-py311-cu121'\n",
-    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu121'\n",
+    "- For Python 3.12: 'quay.io/modh/ray:2.47.1-py312-cu128'\n",
     "\n",
     "If you prefer to use a custom Ray image that better suits your needs, you can specify it in the image field to override the default."
    ]

--- a/src/codeflare_sdk/common/utils/constants.py
+++ b/src/codeflare_sdk/common/utils/constants.py
@@ -2,10 +2,10 @@ RAY_VERSION = "2.47.1"
 """
 The below are used to define the default runtime image for the Ray Cluster.
 * For python 3.11:ray:2.47.1-py311-cu121
-* For python 3.12:ray:2.47.1-py312-cu121
+* For python 3.12:ray:2.47.1-py312-cu128
 """
 CUDA_PY311_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e"
-CUDA_PY312_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:23860dfe2e47bb69709b3883b08fd1a4d836ce02eaf8d0afeeafe6986d0fc8fb"
+CUDA_PY312_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:9c72e890f5c66bb2a0f0d940120539ffc875fb6fed83380cbe2eba938e8789b1"
 
 # Centralized image selection
 SUPPORTED_PYTHON_VERSIONS = {


### PR DESCRIPTION
# Issue link
[Jira Link](https://issues.redhat.com/browse/RHOAIENG-33492)

# What changes have been made
Accounting for the recent bump to CUDA 12.8 for our Python 3.12 runtime image, this PR serves to update the default runtime image in the SDK to this.

# Verification steps
* Build a `.whl` file from this branch.
* Pip install it in a jupyter notebook (ensuring that you have access to GPUs).
* Run through the `cluster_job_client` notebook.
* Monitor GPU usage in the Ray Dashboard.
* Verify CUDA version by running `ncvv --version` in the head pods terminal.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->