### PR TITLE
task(RHOAIENG-34228): CodeFlare SDK Patch release 0.31.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
 name = "codeflare-sdk"
-version = "0.31.0"
+version = "0.31.1"
 
 [tool.poetry]
 name = "codeflare-sdk"
-version = "0.31.0"
+version = "0.31.1"
 description = "Python SDK for codeflare client"
 
 license = "Apache-2.0"

--- a/src/codeflare_sdk/common/utils/constants.py
+++ b/src/codeflare_sdk/common/utils/constants.py
@@ -5,7 +5,7 @@ The below are used to define the default runtime image for the Ray Cluster.
 * For python 3.12:ray:2.47.1-py312-cu128
 """
 CUDA_PY311_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e"
-CUDA_PY312_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:9c72e890f5c66bb2a0f0d940120539ffc875fb6fed83380cbe2eba938e8789b1"
+CUDA_PY312_RUNTIME_IMAGE = "quay.io/modh/ray@sha256:fb6f207de63e442c67bb48955cf0584f3704281faf17b90419cfa274fdec63c5"
 
 # Centralized image selection
 SUPPORTED_PYTHON_VERSIONS = {


### PR DESCRIPTION
# Issue link
[Jira Link](https://issues.redhat.com/browse/RHOAIENG-34228)

# What changes have been made
Patch the codeflare sdk to account for `pyproject.toml` metadata mismatch and to include new multi-arch CUDA build as default image.

# Verification steps
N/A

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->