### PR TITLE
[WIP] Add Ray Native Token Authentication

### DIFF
--- a/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
@@ -174,6 +174,12 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
         },
     }
 
+    # Enable Ray token authentication by default for defense-in-depth security.
+    # KubeRay v1.5.1+ creates a Secret with a randomly generated token and injects
+    # RAY_AUTH_TOKEN and RAY_AUTH_MODE environment variables into all Ray containers.
+    if cluster.config.enable_ray_token_auth:
+        resource["spec"]["authOptions"] = {"mode": "token"}
+
     if cluster.config.enable_gcs_ft:
         if not cluster.config.redis_address:
             raise ValueError(

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -94,6 +94,12 @@ class ClusterConfiguration:
             Kubernetes secret reference containing Redis password. ex: {"name": "secret-name", "key": "password-key"}
         external_storage_namespace:
             The storage namespace to use for GCS fault tolerance. By default, KubeRay sets it to the UID of RayCluster.
+        enable_ray_token_auth:
+            A boolean indicating whether to enable Ray token authentication.
+            When enabled (default), KubeRay creates a Secret with a randomly generated token
+            and sets RAY_AUTH_TOKEN and RAY_AUTH_MODE environment variables on all Ray containers.
+            Requires Ray 2.52.0+ and KubeRay v1.5.1+. Provides defense-in-depth security
+            alongside OpenShift OAuth/OIDC authentication.
     """
 
     name: str
@@ -133,6 +139,7 @@ class ClusterConfiguration:
     redis_address: Optional[str] = None
     redis_password_secret: Optional[Dict[str, str]] = None
     external_storage_namespace: Optional[str] = None
+    enable_ray_token_auth: bool = True  # Enabled by default for defense-in-depth
 
     def __post_init__(self):
         if not self.verify_tls:


### PR DESCRIPTION
**DISCLAIMER: This can only be finalized and tested after we bump to Ray v2.52.1 and Kuberay v1.5.1**
# Issue link
[RHOAIENG-39762](https://issues.redhat.com/browse/RHOAIENG-39762)

# What changes have been made
- Added enable_ray_token_auth configuration option (default True) to enable Ray token authentication via KubeRay's authOptions API
- Implemented automatic Ray token retrieval and environment variable setup in SDK, enabling standard ray.init() to work with authenticated clusters

## Why
- Enables ray.init() (currently broken with OAuth proxy) **Cursor seems to think this - haven't tested it**
- adds application-layer token auth alongside network-layer OAuth/OIDC
- SDK handles token retrieval and env vars transparently

### Security layers:
- OAuth - Gateway API: Network layer (validates identity for external access)
- Ray Token Auth: Application layer (validates token for all Ray API calls, including pod-to-pod)
If one layer is bypassed, the other still protects.

# Verification steps
N/A
## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->