### PR TITLE
RHOAIENG-29722: use cluster.apply() in demo text

### DIFF
--- a/demo-notebooks/additional-demos/hf_interactive.ipynb
+++ b/demo-notebooks/additional-demos/hf_interactive.ipynb
@@ -127,7 +127,7 @@
    "id": "12eef53c",
    "metadata": {},
    "source": [
-    "Next, we want to bring our cluster up, so we call the `up()` function below to submit our Ray Cluster onto the queue, and begin the process of obtaining our resource cluster."
+    "Next, we want to bring our cluster up, so we call `cluster.apply()` below to submit our Ray Cluster onto the queue, and begin the process of obtaining our resource cluster."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/notebook-ex-outputs/0_basic_ray.ipynb
@@ -103,7 +103,7 @@
    "id": "12eef53c",
    "metadata": {},
    "source": [
-    "Next, we want to bring our cluster up, so we call the `up()` function below to submit our Ray Cluster onto the queue, and begin the process of obtaining our resource cluster."
+    "Next, we want to bring our cluster up, so we call `cluster.apply()` below to submit our Ray Cluster onto the queue, and begin the process of obtaining our resource cluster."
    ]
   },
   {

--- a/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
+++ b/demo-notebooks/guided-demos/preview_nbs/0_basic_ray.ipynb
@@ -103,7 +103,7 @@
    "id": "12eef53c",
    "metadata": {},
    "source": [
-    "Next, we want to bring our cluster up, so we call the `up()` function below to submit our Ray Cluster onto the queue, and begin the process of obtaining our resource cluster."
+    "Next, we want to bring our cluster up, so we call `cluster.apply()` below to submit our Ray Cluster onto the queue, and begin the process of obtaining our resource cluster."
    ]
   },
   {


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/RHOAIENG-29722

# What changes have been made

- Notebook markdown in three demos now says cluster.apply() instead of up() (code was already apply()).

# Verification steps

- Verify those cells: text and code both reference cluster.apply().

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change