### PR TITLE
RHOAIENG-54719 fix list_local_queues KeyError on missing status

### DIFF
--- a/src/codeflare_sdk/common/kueue/kueue.py
+++ b/src/codeflare_sdk/common/kueue/kueue.py
@@ -107,6 +107,8 @@ def list_local_queues(
 
     Note:
         Depending on the version of the local queue API, the available flavors may not be present in the response.
+        A ``LocalQueue`` may also appear without a ``status`` (or with empty status) until the Kueue controller
+        reconciles; such queues are still returned, usually without a ``flavors`` key on the dict.
 
     Args:
         namespace (str, optional):
@@ -127,8 +129,10 @@ def list_local_queues(
     to_return = []
     for lq in local_queues["items"]:
         item = {"name": lq["metadata"]["name"]}
-        if "flavors" in lq["status"]:
-            item["flavors"] = [f["name"] for f in lq["status"]["flavors"]]
+        # LocalQueue may exist before Kueue populates .status (RHOAIENG-54719).
+        lq_status = lq.get("status") or {}
+        if "flavors" in lq_status:
+            item["flavors"] = [f["name"] for f in lq_status["flavors"]]
             if flavors is not None and not set(flavors).issubset(set(item["flavors"])):
                 continue
         elif flavors is not None:

--- a/src/codeflare_sdk/common/kueue/test_kueue.py
+++ b/src/codeflare_sdk/common/kueue/test_kueue.py
@@ -144,6 +144,31 @@ def test_list_local_queues(mocker):
     assert lqs == []
 
 
+def test_list_local_queues_no_status(mocker):
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch(
+        "kubernetes.client.CustomObjectsApi.list_namespaced_custom_object",
+        return_value={
+            "items": [
+                {"metadata": {"name": "a"}},
+                {"metadata": {"name": "b"}, "status": None},
+                {
+                    "metadata": {"name": "c"},
+                    "status": {"flavors": [{"name": "default"}]},
+                },
+            ]
+        },
+    )
+    assert list_local_queues("ns") == [
+        {"name": "a"},
+        {"name": "b"},
+        {"name": "c", "flavors": ["default"]},
+    ]
+    assert list_local_queues("ns", flavors=["default"]) == [
+        {"name": "c", "flavors": ["default"]},
+    ]
+
+
 def test_get_default_kueue_name_found(mocker):
     mocker.patch("kubernetes.config.load_kube_config", return_value="ignore")
     mock_api_instance = mocker.Mock()


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/RHOAIENG-54719

# What changes have been made

- list_local_queues() (kueue.py): stop indexing lq["status"] directly. Use lq_status = lq.get("status") or {} before checking flavors, so missing or null status does not raise KeyError, queues still appear (usually without a flavors key until Kueue reconciles).

- Tests (test_kueue.py): test_list_local_queues_no_status covers no status, status: None, and normal flavor filtering.

# Verification steps

- Unit tests: poetry run pytest src/codeflare_sdk/common/kueue/test_kueue.py -q
- Manual (cluster with Kueue): create a LocalQueue, call list_local_queues(namespace=...) immediately (or run the verification notebook); confirm no KeyError and entries without flavors when status is not ready yet.

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change