### PR TITLE
fix(cluster): map all CodeFlareClusterStatus values to RayClusterStatus in _copy_to_ray()

### DIFF
--- a/src/codeflare_sdk/ray/cluster/cluster.py
+++ b/src/codeflare_sdk/ray/cluster/cluster.py
@@ -1199,10 +1199,22 @@ def _map_to_ray_cluster(rc) -> Optional[RayCluster]:
     )
 
 
+_CODEFLARE_TO_RAY_STATUS = {
+    CodeFlareClusterStatus.READY: RayClusterStatus.READY,
+    CodeFlareClusterStatus.FAILED: RayClusterStatus.FAILED,
+    CodeFlareClusterStatus.SUSPENDED: RayClusterStatus.SUSPENDED,
+    CodeFlareClusterStatus.UNKNOWN: RayClusterStatus.UNKNOWN,
+    CodeFlareClusterStatus.STARTING: RayClusterStatus.UNKNOWN,
+    CodeFlareClusterStatus.QUEUED: RayClusterStatus.UNKNOWN,
+    CodeFlareClusterStatus.QUEUEING: RayClusterStatus.UNKNOWN,
+}
+
+
 def _copy_to_ray(cluster: Cluster) -> RayCluster:
-    ray = RayCluster(
+    cf_status = cluster.status(print_to_console=False)[0]
+    return RayCluster(
         name=cluster.config.name,
-        status=cluster.status(print_to_console=False)[0],
+        status=_CODEFLARE_TO_RAY_STATUS.get(cf_status, RayClusterStatus.UNKNOWN),
         num_workers=cluster.config.num_workers,
         worker_mem_requests=cluster.config.worker_memory_requests,
         worker_mem_limits=cluster.config.worker_memory_limits,
@@ -1217,9 +1229,6 @@ def _copy_to_ray(cluster: Cluster) -> RayCluster:
         head_cpu_limits=cluster.config.head_cpu_limits,
         head_extended_resources=cluster.config.head_extended_resource_requests,
     )
-    if ray.status == CodeFlareClusterStatus.READY:
-        ray.status = RayClusterStatus.READY
-    return ray
 
 
 # Check if the routes api exists

--- a/src/codeflare_sdk/ray/cluster/test_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/test_cluster.py
@@ -32,6 +32,7 @@ from codeflare_sdk.common.utils.unit_test_support import (
     route_list_retrieval,
 )
 from codeflare_sdk.ray.cluster.cluster import _is_openshift_cluster
+from codeflare_sdk.ray.cluster.status import CodeFlareClusterStatus, RayClusterStatus
 from pathlib import Path
 from unittest.mock import MagicMock
 from kubernetes import client
@@ -45,6 +46,31 @@ import tempfile
 parent = Path(__file__).resolve().parents[4]  # project directory
 expected_clusters_dir = f"{parent}/tests/test_cluster_yamls"
 cluster_dir = os.path.expanduser("~/.codeflare/resources/")
+
+
+@pytest.mark.parametrize(
+    "cf_status,expected_ray_status",
+    [
+        (CodeFlareClusterStatus.READY, RayClusterStatus.READY),
+        (CodeFlareClusterStatus.FAILED, RayClusterStatus.FAILED),
+        (CodeFlareClusterStatus.SUSPENDED, RayClusterStatus.SUSPENDED),
+        (CodeFlareClusterStatus.UNKNOWN, RayClusterStatus.UNKNOWN),
+        (CodeFlareClusterStatus.STARTING, RayClusterStatus.UNKNOWN),
+        (CodeFlareClusterStatus.QUEUED, RayClusterStatus.UNKNOWN),
+        (CodeFlareClusterStatus.QUEUEING, RayClusterStatus.UNKNOWN),
+    ],
+)
+def test_details_maps_codeflare_status_to_ray_status(
+    mocker, cf_status, expected_ray_status
+):
+    cluster = create_cluster(mocker)
+    mocker.patch.object(cluster, "status", return_value=(cf_status, ""))
+    mocker.patch.object(cluster, "cluster_dashboard_uri", return_value="http://fake")
+
+    ray_cluster = cluster.details(print_to_console=False)
+
+    assert ray_cluster.status == expected_ray_status
+    assert isinstance(ray_cluster.status, RayClusterStatus)
 
 
 def test_cluster_apply_down(mocker):


### PR DESCRIPTION
## Description

`_copy_to_ray()` only mapped `CodeFlareClusterStatus.READY` to `RayClusterStatus.READY`. All other statuses were passed through as `CodeFlareClusterStatus` enum values, so downstream comparisons against `RayClusterStatus` silently failed.

Replaced the single-case `if` with an explicit `_CODEFLARE_TO_RAY_STATUS` mapping dict that covers every `CodeFlareClusterStatus` member. States with a direct `RayClusterStatus` equivalent (`READY`, `FAILED`, `SUSPENDED`, `UNKNOWN`) map 1:1. CodeFlare-only states (`STARTING`, `QUEUED`, `QUEUEING`) map to `RayClusterStatus.UNKNOWN`.

Added a parametrized unit test covering all 7 enum values.

## Verification steps

### Prerequisites

- An OpenShift or kind cluster with the KubeRay operator installed

### 2. Verification

Create a suspended RayCluster:

```bash
cat <<'EOF' | kubectl apply -f -
apiVersion: ray.io/v1
kind: RayCluster
metadata:
  name: test-54700-suspended
  namespace: default
spec:
  suspend: true
  rayVersion: "2.53.0"
  headGroupSpec:
    rayStartParams: { dashboard-host: "0.0.0.0" }
    template:
      spec:
        containers:
        - name: ray-head
          image: rayproject/ray:2.53.0
          resources:
            requests: { cpu: "500m", memory: "512Mi" }
            limits:   { cpu: "1",    memory: "1Gi"   }
  workerGroupSpecs:
  - groupName: small-group
    replicas: 1
    template:
      spec:
        containers:
        - name: ray-worker
          image: rayproject/ray:2.53.0
          resources:
            requests: { cpu: "500m", memory: "512Mi" }
            limits:   { cpu: "1",    memory: "1Gi"   }
EOF
```

Verify `details()` returns the correct type and value:

```python
from kubernetes import client, config
from codeflare_sdk import set_api_client
from codeflare_sdk.ray.cluster.cluster import get_cluster
from codeflare_sdk.ray.cluster.status import RayClusterStatus

config.load_kube_config()
set_api_client(client.ApiClient())

cluster = get_cluster("test-54700-suspended", namespace="default")
ray = cluster.details(print_to_console=False)
print(type(ray.status))                          # <enum 'RayClusterStatus'>
print(ray.status == RayClusterStatus.SUSPENDED)   # True
```

To also check the failed state, patch the same cluster:

```bash
kubectl patch raycluster test-54700-suspended -n default \
  --type=merge --subresource=status -p '{"status":{"state":"failed"}}' \
  && kubectl patch raycluster test-54700-suspended -n default \
  --type=merge -p '{"spec":{"suspend":false}}'
```

```python
cluster = get_cluster("test-54700-suspended", namespace="default")
ray = cluster.details(print_to_console=False)
print(type(ray.status))                        # <enum 'RayClusterStatus'>
print(ray.status == RayClusterStatus.FAILED)    # True
```

### Cleanup

```bash
kubectl delete raycluster test-54700-suspended -n default
```

Resolves: [RHOAIENG-54700](https://redhat.atlassian.net/browse/RHOAIENG-54700)