### PR TITLE
task(RHOAIENG-57450): Expose autoscaling in ClusterConfiguration

### DIFF
--- a/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
@@ -115,6 +115,17 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
     worker_resources = json.dumps(worker_resources).replace('"', '\\"')
     worker_resources = f'"{worker_resources}"'
 
+    # Determine autoscaling vs fixed-size worker replica settings
+    autoscaling_enabled = cluster.config.enable_autoscaling
+    if autoscaling_enabled:
+        worker_replicas = cluster.config.min_workers
+        worker_min_replicas = cluster.config.min_workers
+        worker_max_replicas = cluster.config.max_workers
+    else:
+        worker_replicas = cluster.config.num_workers
+        worker_min_replicas = cluster.config.num_workers
+        worker_max_replicas = cluster.config.num_workers
+
     # Create the Ray Cluster using the V1RayCluster Object
     resource = {
         "apiVersion": "ray.io/v1",
@@ -122,7 +133,7 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
         "metadata": get_metadata(cluster),
         "spec": {
             "rayVersion": RAY_VERSION,
-            "enableInTreeAutoscaling": False,
+            "enableInTreeAutoscaling": autoscaling_enabled,
             "autoscalerOptions": {
                 "upscalingMode": "Default",
                 "idleTimeoutSeconds": 60,
@@ -152,9 +163,9 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
             },
             "workerGroupSpecs": [
                 {
-                    "replicas": cluster.config.num_workers,
-                    "minReplicas": cluster.config.num_workers,
-                    "maxReplicas": cluster.config.num_workers,
+                    "replicas": worker_replicas,
+                    "minReplicas": worker_min_replicas,
+                    "maxReplicas": worker_max_replicas,
                     "groupName": f"small-group-{cluster.config.name}",
                     "rayStartParams": {
                         "block": "true",

--- a/src/codeflare_sdk/ray/cluster/cluster.py
+++ b/src/codeflare_sdk/ray/cluster/cluster.py
@@ -871,20 +871,29 @@ def get_cluster(
     ) = Cluster._head_worker_extended_resources_from_rc_dict(resource)
 
     # Fix for RHOAIENG-54729: Handle head-only clusters (no workers)
+    enable_autoscaling = resource["spec"].get("enableInTreeAutoscaling", False)
+    min_workers = None
+    max_workers = None
+
     if len(resource["spec"].get("workerGroupSpecs", [])) > 0:
-        num_workers = resource["spec"]["workerGroupSpecs"][0]["minReplicas"]
-        worker_cpu_limits = resource["spec"]["workerGroupSpecs"][0]["template"]["spec"][
-            "containers"
-        ][0]["resources"]["limits"]["cpu"]
-        worker_cpu_requests = resource["spec"]["workerGroupSpecs"][0]["template"][
-            "spec"
-        ]["containers"][0]["resources"]["requests"]["cpu"]
-        worker_memory_limits = resource["spec"]["workerGroupSpecs"][0]["template"][
-            "spec"
-        ]["containers"][0]["resources"]["limits"]["memory"]
-        worker_memory_requests = resource["spec"]["workerGroupSpecs"][0]["template"][
-            "spec"
-        ]["containers"][0]["resources"]["requests"]["memory"]
+        worker_group = resource["spec"]["workerGroupSpecs"][0]
+        num_workers = worker_group["minReplicas"]
+        worker_cpu_limits = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["limits"]["cpu"]
+        worker_cpu_requests = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["requests"]["cpu"]
+        worker_memory_limits = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["limits"]["memory"]
+        worker_memory_requests = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["requests"]["memory"]
+
+        if enable_autoscaling:
+            min_workers = worker_group.get("minReplicas", num_workers)
+            max_workers = worker_group.get("maxReplicas", num_workers)
     else:
         # Head-only cluster - use defaults for worker specs
         num_workers = 0
@@ -918,6 +927,9 @@ def get_cluster(
         worker_memory_requests=worker_memory_requests,
         head_extended_resource_requests=head_extended_resources,
         worker_extended_resource_requests=worker_extended_resources,
+        enable_autoscaling=enable_autoscaling,
+        min_workers=min_workers,
+        max_workers=max_workers,
     )
 
     # Ignore the warning here for the lack of a ClusterConfiguration
@@ -1150,19 +1162,20 @@ def _map_to_ray_cluster(rc) -> Optional[RayCluster]:
 
     # Fix for RHOAIENG-54729: Handle head-only clusters (no workers)
     if len(rc["spec"].get("workerGroupSpecs", [])) > 0:
-        num_workers = rc["spec"]["workerGroupSpecs"][0]["replicas"]
-        worker_mem_limits = rc["spec"]["workerGroupSpecs"][0]["template"]["spec"][
-            "containers"
-        ][0]["resources"]["limits"]["memory"]
-        worker_mem_requests = rc["spec"]["workerGroupSpecs"][0]["template"]["spec"][
-            "containers"
-        ][0]["resources"]["requests"]["memory"]
-        worker_cpu_requests = rc["spec"]["workerGroupSpecs"][0]["template"]["spec"][
-            "containers"
-        ][0]["resources"]["requests"]["cpu"]
-        worker_cpu_limits = rc["spec"]["workerGroupSpecs"][0]["template"]["spec"][
-            "containers"
-        ][0]["resources"]["limits"]["cpu"]
+        worker_group = rc["spec"]["workerGroupSpecs"][0]
+        num_workers = worker_group["replicas"]
+        worker_mem_limits = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["limits"]["memory"]
+        worker_mem_requests = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["requests"]["memory"]
+        worker_cpu_requests = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["requests"]["cpu"]
+        worker_cpu_limits = worker_group["template"]["spec"]["containers"][0][
+            "resources"
+        ]["limits"]["cpu"]
     else:
         # Head-only cluster - use defaults for worker specs
         num_workers = 0
@@ -1174,7 +1187,6 @@ def _map_to_ray_cluster(rc) -> Optional[RayCluster]:
     return RayCluster(
         name=rc["metadata"]["name"],
         status=status,
-        # for now we are not using autoscaling so same replicas is fine
         num_workers=num_workers,
         worker_mem_limits=worker_mem_limits,
         worker_mem_requests=worker_mem_requests,

--- a/src/codeflare_sdk/ray/cluster/config.py
+++ b/src/codeflare_sdk/ray/cluster/config.py
@@ -97,6 +97,17 @@ class ClusterConfiguration:
             A list of V1Volume objects to add to the Cluster
         volume_mounts:
             A list of V1VolumeMount objects to add to the Cluster
+        enable_autoscaling:
+            A boolean indicating whether to enable Ray in-tree autoscaling. When True,
+            min_workers and max_workers must also be set. Cannot be used with Kueue
+            (local_queue) until upstream KEP-77 graduates.
+        min_workers:
+            Minimum number of workers when autoscaling is enabled. Maps to
+            workerGroupSpecs.replicas and workerGroupSpecs.minReplicas.
+            Required when enable_autoscaling is True.
+        max_workers:
+            Maximum number of workers when autoscaling is enabled. Maps to
+            workerGroupSpecs.maxReplicas. Required when enable_autoscaling is True.
         enable_gcs_ft:
             A boolean indicating whether to enable GCS fault tolerance.
         enable_usage_stats:
@@ -137,6 +148,9 @@ class ClusterConfiguration:
     extended_resource_mapping: Dict[str, str] = field(default_factory=dict)
     overwrite_default_resource_mapping: bool = False
     local_queue: Optional[str] = None
+    enable_autoscaling: bool = False
+    min_workers: Optional[int] = None
+    max_workers: Optional[int] = None
     annotations: Dict[str, str] = field(default_factory=dict)
     volumes: list[V1Volume] = field(default_factory=list)
     volume_mounts: list[V1VolumeMount] = field(default_factory=list)
@@ -151,6 +165,8 @@ class ClusterConfiguration:
             print(
                 "Warning: TLS verification has been disabled - Endpoint checks will be bypassed"
             )
+
+        self._validate_autoscaling()
 
         if self.enable_usage_stats:
             self.envs["RAY_USAGE_STATS_ENABLED"] = "1"
@@ -211,6 +227,23 @@ class ClusterConfiguration:
             if k not in self.extended_resource_mapping.keys():
                 raise ValueError(
                     f"extended resource '{k}' not found in extended_resource_mapping, available resources are {list(self.extended_resource_mapping.keys())}, to add more supported resources use extended_resource_mapping. i.e. extended_resource_mapping = {{'{k}': 'FOO_BAR'}}"
+                )
+
+    def _validate_autoscaling(self):
+        if self.enable_autoscaling:
+            if self.min_workers is None or self.max_workers is None:
+                raise ValueError(
+                    "min_workers and max_workers must be provided when enable_autoscaling is True"
+                )
+            if self.min_workers < 0:
+                raise ValueError("min_workers must be >= 0")
+            if self.max_workers < self.min_workers:
+                raise ValueError("max_workers must be >= min_workers")
+        else:
+            if self.min_workers is not None or self.max_workers is not None:
+                warnings.warn(
+                    "min_workers and max_workers are ignored when enable_autoscaling is False",
+                    UserWarning,
                 )
 
     def _str_mem_no_unit_add_GB(self):

--- a/src/codeflare_sdk/ray/cluster/test_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/test_cluster.py
@@ -2144,6 +2144,72 @@ def test_job_logs(mocker):
     mock_job_client.get_job_logs.assert_called_once_with("job-123")
 
 
+def test_get_cluster_autoscaling(mocker):
+    """
+    Test that get_cluster correctly reconstructs autoscaling config
+    when the RayCluster has enableInTreeAutoscaling: true.
+    Covers the enable_autoscaling branch in get_cluster().
+    """
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch("kubernetes.config.load_kube_config", return_value="ignore")
+
+    autoscaling_rc = {
+        "apiVersion": "ray.io/v1",
+        "kind": "RayCluster",
+        "metadata": {"name": "autoscale-cluster", "namespace": "ns"},
+        "spec": {
+            "enableInTreeAutoscaling": True,
+            "headGroupSpec": {
+                "template": {
+                    "spec": {
+                        "containers": [
+                            {
+                                "name": "ray-head",
+                                "resources": {
+                                    "limits": {"cpu": "2", "memory": "8G"},
+                                    "requests": {"cpu": "2", "memory": "8G"},
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+            "workerGroupSpecs": [
+                {
+                    "replicas": 1,
+                    "minReplicas": 1,
+                    "maxReplicas": 8,
+                    "groupName": "small-group-autoscale",
+                    "template": {
+                        "spec": {
+                            "containers": [
+                                {
+                                    "name": "machine-learning",
+                                    "resources": {
+                                        "limits": {"cpu": "4", "memory": "6G"},
+                                        "requests": {"cpu": "2", "memory": "4G"},
+                                    },
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        },
+    }
+
+    mocker.patch(
+        "kubernetes.client.CustomObjectsApi.get_namespaced_custom_object",
+        return_value=autoscaling_rc,
+    )
+
+    cluster = get_cluster("autoscale-cluster", "ns")
+    assert cluster.config.enable_autoscaling is True
+    assert cluster.config.min_workers == 1
+    assert cluster.config.max_workers == 8
+    assert cluster.config.num_workers == 1
+
+
 def test_head_only_cluster_no_workers(mocker):
     """
     Test for RHOAIENG-54729: Functions should handle head-only clusters (num_workers=0)

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -210,6 +210,130 @@ def test_cluster_name_validation():
         ClusterConfiguration(name="-testcluster", namespace="ns")
 
 
+def test_autoscaling_config_valid():
+    config = ClusterConfiguration(
+        name="autoscale-test",
+        namespace="ns",
+        enable_autoscaling=True,
+        min_workers=1,
+        max_workers=8,
+    )
+    assert config.enable_autoscaling is True
+    assert config.min_workers == 1
+    assert config.max_workers == 8
+
+
+def test_autoscaling_config_zero_min_workers():
+    config = ClusterConfiguration(
+        name="autoscale-zero-min",
+        namespace="ns",
+        enable_autoscaling=True,
+        min_workers=0,
+        max_workers=4,
+    )
+    assert config.min_workers == 0
+    assert config.max_workers == 4
+
+
+def test_autoscaling_config_missing_workers():
+    with pytest.raises(
+        ValueError, match="min_workers and max_workers must be provided"
+    ):
+        ClusterConfiguration(
+            name="autoscale-missing",
+            namespace="ns",
+            enable_autoscaling=True,
+        )
+
+
+def test_autoscaling_config_missing_max_workers():
+    with pytest.raises(
+        ValueError, match="min_workers and max_workers must be provided"
+    ):
+        ClusterConfiguration(
+            name="autoscale-missing-max",
+            namespace="ns",
+            enable_autoscaling=True,
+            min_workers=1,
+        )
+
+
+def test_autoscaling_config_negative_min_workers():
+    with pytest.raises(ValueError, match="min_workers must be >= 0"):
+        ClusterConfiguration(
+            name="autoscale-negative",
+            namespace="ns",
+            enable_autoscaling=True,
+            min_workers=-1,
+            max_workers=4,
+        )
+
+
+def test_autoscaling_config_max_less_than_min():
+    with pytest.raises(ValueError, match="max_workers must be >= min_workers"):
+        ClusterConfiguration(
+            name="autoscale-bad-range",
+            namespace="ns",
+            enable_autoscaling=True,
+            min_workers=5,
+            max_workers=2,
+        )
+
+
+def test_autoscaling_disabled_ignores_workers():
+    with pytest.warns(UserWarning, match="min_workers and max_workers are ignored"):
+        config = ClusterConfiguration(
+            name="no-autoscale",
+            namespace="ns",
+            enable_autoscaling=False,
+            min_workers=1,
+            max_workers=8,
+        )
+    assert config.enable_autoscaling is False
+
+
+def test_autoscaling_spec_generation(mocker):
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
+
+    cluster = Cluster(
+        ClusterConfiguration(
+            name="autoscale-cluster",
+            namespace="ns",
+            enable_autoscaling=True,
+            min_workers=2,
+            max_workers=10,
+        )
+    )
+
+    spec = cluster.resource_yaml["spec"]
+    assert spec["enableInTreeAutoscaling"] is True
+    worker_group = spec["workerGroupSpecs"][0]
+    assert worker_group["replicas"] == 2
+    assert worker_group["minReplicas"] == 2
+    assert worker_group["maxReplicas"] == 10
+
+
+def test_autoscaling_disabled_spec_unchanged(mocker):
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
+
+    cluster = Cluster(
+        ClusterConfiguration(
+            name="fixed-cluster",
+            namespace="ns",
+            num_workers=3,
+        )
+    )
+
+    spec = cluster.resource_yaml["spec"]
+    assert spec["enableInTreeAutoscaling"] is False
+    worker_group = spec["workerGroupSpecs"][0]
+    assert worker_group["replicas"] == 3
+    assert worker_group["minReplicas"] == 3
+    assert worker_group["maxReplicas"] == 3
+
+
 # Make sure to always keep this function last
 def test_cleanup():
     os.remove(f"{cluster_dir}test-all-params.yaml")


### PR DESCRIPTION
# Issue link
[Jira](https://redhat.atlassian.net/browse/RHOAIENG-57450)

# What changes have been made
Exposed Ray autoscaling via cluster config within the SDK.

# Verification steps

### Prerequisites
- Access to an OpenShift cluster with KubeRay installed
- Kueue **not** managing the target namespace
- `codeflare-sdk` installed from the `RHOAIENG-57450` branch

### 1. Create and submit an autoscaling RayCluster

```python
from codeflare_sdk import Cluster, ClusterConfiguration

cluster = Cluster(ClusterConfiguration(
    name="autoscale-verify",
    namespace="default",
    num_workers=1,
    enable_autoscaling=True,
    min_workers=1,
    max_workers=4,
    worker_cpu_requests=1,
    worker_cpu_limits=1,
    worker_memory_requests=2,
    worker_memory_limits=4,
))

cluster.up()
cluster.wait_ready()
```

### 2. Verify the RayCluster spec (`oc`)

```bash
# Confirm the CR was created with autoscaling fields
oc get raycluster autoscale-verify -n default -o jsonpath='{.spec.enableInTreeAutoscaling}'
# Expected: true

oc get raycluster autoscale-verify -n default -o jsonpath='{.spec.workerGroupSpecs[0].minReplicas}'
# Expected: 1

oc get raycluster autoscale-verify -n default -o jsonpath='{.spec.workerGroupSpecs[0].maxReplicas}'
# Expected: 4

# Confirm initial worker pod count matches minReplicas
oc get pods -n default -l ray.io/node-type=worker,ray.io/cluster=autoscale-verify
# Expected: 1 Running pod
```

### 3. Submit a workload that triggers scale-up

```python
import ray

ray.init(address=cluster.cluster_uri())

@ray.remote(num_cpus=1)
def burn_cpu():
    """Each task claims 1 full CPU, blocking the worker."""
    import time
    time.sleep(120)
    return True

# Launch more tasks than a single worker can handle.
# With 1 CPU per worker, 4 concurrent tasks forces the
# autoscaler to request up to max_workers.
futures = [burn_cpu.remote() for _ in range(4)]

# Don't block — let the autoscaler react while we observe.
```

### 4. Observe scale-up (`oc`)

```bash
# Watch worker pods scale up (repeat or use -w)
oc get pods -n default -l ray.io/node-type=worker,ray.io/cluster=autoscale-verify -w

# Check the autoscaler sidecar logs on the head pod
HEAD_POD=$(oc get pods -n default -l ray.io/node-type=head,ray.io/cluster=autoscale-verify -o jsonpath='{.items[0].metadata.name}')
oc logs "$HEAD_POD" -n default -c autoscaler

# Confirm replicas updated on the CR
oc get raycluster autoscale-verify -n default -o jsonpath='{.spec.workerGroupSpecs[0].replicas}'
# Expected: increases towards 4
```

### 5. Observe scale-down (`oc`)

Wait for the `burn_cpu` tasks to complete (~2 min), then wait for the idle timeout (default 60s):

```python
# Collect results in the Python session
results = ray.get(futures)
print(results)  # [True, True, True, True]

ray.shutdown()
```

```bash
# Watch worker pods scale back down
oc get pods -n default -l ray.io/node-type=worker,ray.io/cluster=autoscale-verify -w
# Expected: scales back to 1 (minReplicas) after idle timeout

oc get raycluster autoscale-verify -n default -o jsonpath='{.spec.workerGroupSpecs[0].replicas}'
# Expected: 1
```

### 6. Tear down

```python
cluster.down()
```

```bash
oc get raycluster autoscale-verify -n default
# Expected: not found
```

---

### Blockers for end-to-end verification

Steps 4-5 (live scale-up/down) **cannot be fully verified until both of the following KubeRay fixes land:**

| Blocker | Summary | Impact |
|---|---|---|
| [RHOAIENG-59432](https://redhat.atlassian.net/browse/RHOAIENG-59432) | Autoscaler RoleBinding is bound to SA `{cluster-name}`, but the OAuth proxy controller overrides the head pod SA to `{cluster-name}-oauth-proxy-sa`. The autoscaler sidecar gets **403 Forbidden** when attempting to `get`/`patch` the RayCluster CR. | Autoscaler cannot scale workers at all on RHOAI/ODH clusters with auth injection enabled. |
| [RHOAIENG-57443](https://redhat.atlassian.net/browse/RHOAIENG-57443) | KubeRay-managed NetworkPolicy on the head pod lacks an egress rule for the autoscaler sidecar to reach the Kubernetes API server. | Autoscaler sidecar network calls are dropped; scaling silently fails. |

Steps 1-3 (SDK spec generation and CR creation) can be verified independently of these blockers. Steps 4-6 require both fixes to be present in the deployed KubeRay operator image.


## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->