### PR TITLE
feat(auth): verify API client connectivity in set_api_client

### DIFF
--- a/src/codeflare_sdk/common/kubernetes_cluster/auth.py
+++ b/src/codeflare_sdk/common/kubernetes_cluster/auth.py
@@ -358,3 +358,7 @@ def set_api_client(new_client: client.ApiClient):
     global api_client, config_path
     api_client = new_client
     config_path = "custom"  # Mark as configured with custom client
+    # verify the client works by making a simple API call
+    client.AuthenticationApi(api_client).get_api_group()
+    # print message confirming successful configuration
+    print("Custom API client has been set and verified successfully.")


### PR DESCRIPTION
  Add an authentication check when setting a custom API client to
  catch misconfigured or invalid clients early. The verification
  calls AuthenticationApi.get_api_group() to confirm the client
  can reach the Kubernetes API server before proceeding.

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->