### PR TITLE
fix(ci): remove deprecated --no-update flag from poetry lock

### DIFF
--- a/.github/workflows/update-versions.yaml
+++ b/.github/workflows/update-versions.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Regenerate poetry.lock
         if: inputs.new_ray_version != '' || inputs.new_sdk_version != ''
         run: |
-          poetry lock --no-update
+          poetry lock
           echo "Regenerated poetry.lock"
 
       - name: Update runtime image SHAs


### PR DESCRIPTION
## Summary
The `update-versions` workflow fails at the "Regenerate poetry.lock" step because `poetry lock --no-update` is not a valid option in Poetry 2.x. The GitHub Actions runner installs the latest Poetry (now 2.x), which removed this flag.

In Poetry 2.x, `poetry lock` (without flags) already preserves existing locked versions by default — matching the old `--no-update` semantics from 1.x.

## Changes
- Remove `--no-update` flag from `poetry lock` in the `update-versions` workflow