### PR TITLE
feat(RHOAIEG-57444): Add autoscaling gates for Kueue

### DIFF
--- a/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
+++ b/src/codeflare_sdk/ray/cluster/build_ray_cluster.py
@@ -118,6 +118,17 @@ def build_ray_cluster(cluster: "codeflare_sdk.ray.cluster.Cluster"):
     # Determine autoscaling vs fixed-size worker replica settings
     autoscaling_enabled = cluster.config.enable_autoscaling
     if autoscaling_enabled:
+        from codeflare_sdk.common.kueue.kueue import get_default_kueue_name
+
+        lq_name = cluster.config.local_queue or get_default_kueue_name(
+            cluster.config.namespace
+        )
+        if lq_name is not None:
+            raise ValueError(
+                "Autoscaling is not supported when Kueue is enabled. "
+                "Please remove the autoscaler configuration from your "
+                "ClusterConfiguration."
+            )
         worker_replicas = cluster.config.min_workers
         worker_min_replicas = cluster.config.min_workers
         worker_max_replicas = cluster.config.max_workers

--- a/src/codeflare_sdk/ray/cluster/test_config.py
+++ b/src/codeflare_sdk/ray/cluster/test_config.py
@@ -296,6 +296,10 @@ def test_autoscaling_disabled_ignores_workers():
 def test_autoscaling_spec_generation(mocker):
     mocker.patch("kubernetes.client.ApisApi.get_api_versions")
     mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
+    mocker.patch(
+        "codeflare_sdk.common.kueue.kueue.get_default_kueue_name",
+        return_value=None,
+    )
 
     cluster = Cluster(
         ClusterConfiguration(
@@ -313,6 +317,71 @@ def test_autoscaling_spec_generation(mocker):
     assert worker_group["replicas"] == 2
     assert worker_group["minReplicas"] == 2
     assert worker_group["maxReplicas"] == 10
+
+
+def test_autoscaling_blocked_when_local_queue_set(mocker):
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
+
+    with pytest.raises(
+        ValueError,
+        match="Autoscaling is not supported when Kueue is enabled",
+    ):
+        Cluster(
+            ClusterConfiguration(
+                name="autoscale-kueue-explicit",
+                namespace="ns",
+                enable_autoscaling=True,
+                min_workers=1,
+                max_workers=8,
+                local_queue="my-queue",
+            )
+        )
+
+
+def test_autoscaling_blocked_when_default_queue_exists(mocker):
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
+    mocker.patch(
+        "codeflare_sdk.common.kueue.kueue.get_default_kueue_name",
+        return_value="default-queue",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Autoscaling is not supported when Kueue is enabled",
+    ):
+        Cluster(
+            ClusterConfiguration(
+                name="autoscale-kueue-default",
+                namespace="ns",
+                enable_autoscaling=True,
+                min_workers=1,
+                max_workers=8,
+            )
+        )
+
+
+def test_autoscaling_allowed_when_no_queue(mocker):
+    mocker.patch("kubernetes.client.ApisApi.get_api_versions")
+    mocker.patch("kubernetes.client.CustomObjectsApi.list_namespaced_custom_object")
+    mocker.patch(
+        "codeflare_sdk.common.kueue.kueue.get_default_kueue_name",
+        return_value=None,
+    )
+
+    cluster = Cluster(
+        ClusterConfiguration(
+            name="autoscale-no-kueue",
+            namespace="ns",
+            enable_autoscaling=True,
+            min_workers=1,
+            max_workers=8,
+        )
+    )
+
+    spec = cluster.resource_yaml["spec"]
+    assert spec["enableInTreeAutoscaling"] is True
 
 
 def test_autoscaling_disabled_spec_unchanged(mocker):


### PR DESCRIPTION
# Issue link
[RHOAIENG-57444](https://redhat.atlassian.net/browse/RHOAIENG-57444)

# What changes have been made

Adds a guard in the CodeFlare SDK that blocks autoscaling when Kueue would manage the RayCluster. Autoscaling and Kueue are mutually exclusive — enabling both causes the cluster to hang in a suspended state with no useful error.

The guard fires in `build_ray_cluster()` when `enable_autoscaling=True` and either:
- The user explicitly set `local_queue` in their `ClusterConfiguration`, OR
- A default LocalQueue exists in the target namespace

If either condition is true, the RayCluster would receive a `kueue.x-k8s.io/queue-name` label (making Kueue manage it), so the SDK raises a clear `ValueError` before submission.

This approach is namespace-scoped (no cluster-admin permissions required), reuses existing `get_default_kueue_name()`, and adds zero new API calls.

# Verification steps
## Prerequisites

- Access to an OpenShift cluster with the Kueue operator installed
- `codeflare-sdk` installed from the `RHOAIENG-57444` branch

## 1. Setup: Create a namespace with a LocalQueue

```bash
oc create namespace autoscale-test
cat <<'EOF' | oc apply -f -
apiVersion: kueue.x-k8s.io/v1beta1
kind: LocalQueue
metadata:
  name: test-queue
  namespace: autoscale-test
  annotations:
    kueue.x-k8s.io/default-queue: "true"
spec:
  clusterQueue: default
EOF
```

## 2. Verify autoscaling is BLOCKED when Kueue is active in the namespace

```python
from codeflare_sdk import Cluster, ClusterConfiguration

# Should raise ValueError
Cluster(ClusterConfiguration(
    name="test-block",
    namespace="autoscale-test",
    enable_autoscaling=True,
    min_workers=1,
    max_workers=4,
))
```

**Expected:** `ValueError: Autoscaling is not supported when Kueue is enabled. Please remove the autoscaler configuration from your ClusterConfiguration.`

## 3. Verify autoscaling is ALLOWED when no Kueue queue exists

```python
from codeflare_sdk import Cluster, ClusterConfiguration

# Should succeed (use any namespace without LocalQueues)
cluster = Cluster(ClusterConfiguration(
    name="test-allow",
    namespace="default",
    enable_autoscaling=True,
    min_workers=1,
    max_workers=4,
))
print(cluster.resource_yaml["spec"]["enableInTreeAutoscaling"])  # True
```

**Expected:** Cluster object created successfully with `enableInTreeAutoscaling: true`

## 4. Verify normal Kueue usage (no autoscaling) still works

```python
from codeflare_sdk import Cluster, ClusterConfiguration

# Should succeed — Kueue without autoscaling is fine
cluster = Cluster(ClusterConfiguration(
    name="test-kueue-normal",
    namespace="autoscale-test",
    local_queue="test-queue",
    num_workers=2,
))
print(cluster.resource_yaml["metadata"]["labels"]["kueue.x-k8s.io/queue-name"])  # test-queue
```

**Expected:** Cluster created with queue label applied.

## 5. Cleanup

```bash
oc delete namespace autoscale-test
```

## Checks
- [x] I've made sure the tests are passing. 
- Testing Strategy
   - [x] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->