### PR TITLE
RHOAIENG-61469: fix missing label causing upgrade tests to fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ E2E_TEST_IMAGE ?= quay.io/opendatahub/codeflare-sdk-tests:${E2E_TEST_IMAGE_VERSI
 build-test-image:
 	@echo "Building test image: $(E2E_TEST_IMAGE)"
 	# Build the Docker image using podman
-	podman build -f images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .
+	podman build --platform linux/amd64 -f images/tests/Dockerfile -t $(E2E_TEST_IMAGE) .
 
 # Push the test image
 .PHONY: push-test-image

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -286,20 +286,35 @@ def create_new_local_queue(self, num_queues):
         self.local_queues.append(local_queue_name)
 
 
-def create_namespace_with_name(self, namespace_name):
+def create_namespace_with_name(self, namespace_name, kueue_managed=True):
     self.namespace = namespace_name
+    labels = {"kueue.openshift.io/managed": "true"} if kueue_managed else {}
     try:
         namespace_body = client.V1Namespace(
-            metadata=client.V1ObjectMeta(name=self.namespace)
+            metadata=client.V1ObjectMeta(
+                name=self.namespace,
+                labels=labels,
+            )
         )
         self.api_instance.create_namespace(namespace_body)
     except Exception as e:
         # Check if it's an AlreadyExists error (409 Conflict) and ignore it
         if hasattr(e, "status") and e.status == 409:
-            # Namespace already exists, which is fine - just continue
             print(
                 f"Warning: Namespace '{namespace_name}' already exists, continuing..."
             )
+            if kueue_managed:
+                try:
+                    self.api_instance.patch_namespace(
+                        namespace_name,
+                        {
+                            "metadata": {
+                                "labels": {"kueue.openshift.io/managed": "true"}
+                            }
+                        },
+                    )
+                except Exception:
+                    pass
             return
         return _kube_api_error_handling(e)
 

--- a/tests/ui/pages/distributed_workloads_page.py
+++ b/tests/ui/pages/distributed_workloads_page.py
@@ -1005,7 +1005,7 @@ class DistributedWorkloadsPage:
             # Look for the cluster name in the table
             cluster_cell = self.wait.until(
                 EC.presence_of_element_located(
-                    (By.XPATH, f"//td[contains(text(), '{cluster_name}')]")
+                    (By.XPATH, f"//td[contains(., '{cluster_name}')]")
                 )
             )
             is_visible = cluster_cell.is_displayed()

--- a/tests/upgrade/01_raycluster_sdk_upgrade_test.py
+++ b/tests/upgrade/01_raycluster_sdk_upgrade_test.py
@@ -27,6 +27,9 @@ class TestMNISTRayClusterApply:
             create_cluster_queue(self, cluster_queue, flavor)
             create_resource_flavor(self, flavor)
             create_local_queue(self, cluster_queue, local_queue)
+            # Populate plural lists used by delete_kueue_resources
+            self.cluster_queues = [cluster_queue]
+            self.resource_flavors = [flavor]
         except Exception as e:
             delete_namespace(self)
             delete_kueue_resources(self)
@@ -80,6 +83,7 @@ class TestMNISTRayClusterApply:
                 worker_memory_requests=6,
                 worker_memory_limits=8,
                 image=ray_image,
+                local_queue=local_queue,
                 write_to_file=True,
                 verify_tls=False,
             )


### PR DESCRIPTION
# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
[RHOAIENG-61469](https://redhat.atlassian.net/browse/RHOAIENG-61469): fix missing label causing upgrade tests to fail

# Verification steps
## without fix:

```
19:04:08  === Verifying cluster is in Running or Admitted state ===
19:04:09  Searching for cluster status...
19:04:09  Trying locator: xpath=//span[contains(@class, 'pf-v6-c-label__text')]
19:04:21  Trying locator: xpath=//span[contains(@class, 'pf-v5-c-label__text')]
19:04:29  Trying locator: xpath=//span[contains(@class, 'pf-c-label__text')]
19:04:39  Status label not found, checking for workload metrics table...
19:04:49  ✗ Could not verify cluster status
19:04:50  FAILED
19:04:50  === Pre-upgrade UI test failed, cleaning up namespace: test-ns-rayupgrade ===
19:04:50  Successfully cleaned up namespace: test-ns-rayupgrade
19:04:50  
19:04:50  
19:04:50  =================================== FAILURES ===================================
19:04:50  _ TestDistributedWorkloadsUIPreUpgrade.test_verify_cluster_in_distributed_workloads_ui _
19:04:50  tests/upgrade/02_dashboard_ui_upgrade_test.py:100: in test_verify_cluster_in_distributed_workloads_ui
19:04:50      assert (
19:04:50  E   AssertionError: Cluster in test-ns-rayupgrade should be in Running or Admitted state before upgrade
19:04:50  E   assert False
19:04:50  E    +  where False = <bound method DistributedWorkloadsPage.verify_cluster_running of <pages.distributed_workloads_page.DistributedWorkloadsPage object at 0x7f2d014575c0>>()
19:04:50  E    +    where <bound method DistributedWorkloadsPage.verify_cluster_running of <pages.distributed_workloads_page.DistributedWorkloadsPage object at 0x7f2d014575c0>> = <pages.distributed_workloads_page.DistributedWorkloadsPage object at 0x7f2d014575c0>.verify_cluster_running
19:04:50  =============================== warnings summary ===============================
19:04:50  .venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1373
19:04:50    /codeflare-sdk/.venv/lib/python3.12/site-packages/_pytest/config/__init__.py:1373: PytestConfigWarning: Unknown config option: collect_ignore
19:04:50    
19:04:50      self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")
19:04:50  
19:04:50  tests/upgrade/01_raycluster_sdk_upgrade_test.py::TestMNISTRayClusterApply::test_mnist_ray_cluster_sdk_auth
19:04:50  tests/upgrade/02_dashboard_ui_upgrade_test.py::TestDistributedWorkloadsUIPreUpgrade::test_verify_cluster_in_distributed_workloads_ui
19:04:50    /codeflare-sdk/.venv/lib/python3.12/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'api.ods-qe-aws-01-pool-l6vtf.aws.rh-ods.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
19:04:50      warnings.warn(
19:04:50  
19:04:50  tests/upgrade/01_raycluster_sdk_upgrade_test.py::TestMNISTRayClusterApply::test_mnist_ray_cluster_sdk_auth
19:04:50  tests/upgrade/01_raycluster_sdk_upgrade_test.py::TestMNISTRayClusterApply::test_mnist_ray_cluster_sdk_auth
19:04:50  tests/upgrade/01_raycluster_sdk_upgrade_test.py::TestMNISTRayClusterApply::test_mnist_ray_cluster_sdk_auth
19:04:50    /codeflare-sdk/.venv/lib/python3.12/site-packages/kubernetes/client/rest.py:44: DeprecationWarning: HTTPResponse.getheaders() is deprecated and will be removed in urllib3 v2.6.0. Instead access HTTPResponse.headers directly.
19:04:50      return self.urllib3_response.getheaders()
19:04:50  
19:04:50  -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
19:04:50  --------- generated xml file: /codeflare-sdk/results/xunit_report.xml ----------
19:04:50  =========================== short test summary info ============================
```

## with fix
```
=== Verifying cluster is in Running or Admitted state ===
Searching for cluster status...
Trying locator: xpath=//span[contains(@class, 'pf-v6-c-label__text')]
Found 1 status label(s)
Status text: Admitted
✓ Cluster is in Admitted state

=== Checking Project Metrics tab ===
Current URL before tab click: https://rh-ai.apps.ods-qe-psi-17.osp.rh-ods.com/observe-monitor/workload-metrics/workload-status/test-ns-rayupgrade
Navigating directly to Project Metrics URL: https://rh-ai.apps.ods-qe-psi-17.osp.rh-ods.com/observe-monitor/workload-metrics/project-metrics/test-ns-rayupgrade
URL after navigation: https://rh-ai.apps.ods-qe-psi-17.osp.rh-ods.com/observe-monitor/workload-metrics/project-metrics/test-ns-rayupgrade
✓ Successfully navigated to Project Metrics tab
Waiting for metrics content to load...
Current URL: https://rh-ai.apps.ods-qe-psi-17.osp.rh-ods.com/observe-monitor/workload-metrics/project-metrics/test-ns-rayupgrade
Searching for resource metrics indicators...
Attempt 1/3
Trying locator: xpath=//*[contains(text(), 'Requested resources')]
✓ Found resource metrics using: xpath=//*[contains(text(), 'Requested resources')]

=== Checking Workload Status tab ===
Searching for Workload Status tab...
Trying locator: xpath=//button[contains(@class, 'pf-v6-c-tabs__link') and .//span[text()='Workload status']]
Locator xpath=//button[contains(@class, 'pf-v6-c-tabs__link') and .//span[text()='Workload status']] not found: Message: no such element: Unable to locate element: {"method":"xpath","selector":"//button[contains(
Trying locator: xpath=//button[contains(@class, 'pf-v5-c-tabs__link') and .//span[text()='Workload status']]
Locator xpath=//button[contains(@class, 'pf-v5-c-tabs__link') and .//span[text()='Workload status']] not found: Message: no such element: Unable to locate element: {"method":"xpath","selector":"//button[contains(
Trying locator: xpath=//button[@role='tab' and contains(.//span/text(), 'workload status')]
Found Workload Status tab using: xpath=//button[@role='tab' and contains(.//span/text(), 'workload status')]
Successfully clicked Workload Status tab
Cluster mnist found in workload list: True
Found status (v6 label): Admitted
✓ Cluster mnist status is Admitted

=== Pre-upgrade UI verification completed successfully ===
PASSED
```

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->