### PR TITLE
2.x 3.x upgrade tests post upgrade

### DIFF
--- a/images/tests/Dockerfile
+++ b/images/tests/Dockerfile
@@ -80,6 +80,7 @@ COPY --from=builder /codeflare-sdk/.venv /codeflare-sdk/.venv
 COPY pyproject.toml poetry.lock* ./
 COPY README.md ./
 COPY src/ ./src/
+COPY scripts/migration/ ./scripts/migration/
 COPY tests/ ./tests/
 
 # Copy test runner script, entrypoint, and RBAC file

--- a/scripts/migration/ray_cluster_migration.py
+++ b/scripts/migration/ray_cluster_migration.py
@@ -31,11 +31,8 @@ REQUIREMENTS:
 
 USAGE EXAMPLES:
 
-    # Step 1: Backup - All clusters (you'll be prompted for backup directory)
+    # Step 1: Backup - All clusters
     python ray_cluster_migration.py pre-upgrade
-
-    # Step 1: Backup - With specific directory
-    python ray_cluster_migration.py pre-upgrade ./my-backup-dir
 
     # Step 1: Backup - Specific namespace
     python ray_cluster_migration.py pre-upgrade --namespace my-ns
@@ -43,7 +40,9 @@ USAGE EXAMPLES:
     # Step 1: Backup - Single cluster
     python ray_cluster_migration.py pre-upgrade --cluster my-cluster --namespace my-ns
 
-    # ... Perform RHOAI upgrade ...
+    Backups are saved to $RHOAI_UPGRADE_BACKUP_DIR/ray/ (default: /tmp/rhoai-upgrade-backup/ray/)
+
+     # ... Perform RHOAI upgrade ...
 
     # Step 2: Migrate - Start with the same single cluster
     python ray_cluster_migration.py post-upgrade --cluster my-cluster --namespace my-ns --dry-run
@@ -84,44 +83,78 @@ from kubernetes import client, config
 from kubernetes.dynamic import DynamicClient
 from kubernetes.client.rest import ApiException
 
+# Same env as codeflare-sdk tests/upgrade/migration_support.py (default: suppress).
+_SUPPRESS_TLS_WARNINGS_ENV = "RAY_CLUSTER_MIGRATION_SUPPRESS_TLS_WARNINGS"
+
+
+def _configure_tls_warning_suppression() -> None:
+    value = os.environ.get(_SUPPRESS_TLS_WARNINGS_ENV, "1").strip().lower()
+    if value in ("0", "false", "no", "off"):
+        return
+    try:
+        import urllib3
+
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    except Exception:
+        pass
+
+
+_configure_tls_warning_suppression()
+
+RHOAI_UPGRADE_BACKUP_DIR = os.environ.get(
+    "RHOAI_UPGRADE_BACKUP_DIR", "/tmp/rhoai-upgrade-backup"
+)
+
 # Field manager identifier for server-side apply
 CF_SDK_FIELD_MANAGER = "codeflare-sdk"
 
-# Annotation that marks a cluster as migrated
+# Annotation that marks a cluster as migrated (post-upgrade)
 SECURE_NETWORK_ANNOTATION = "odh.ray.io/secure-trusted-network"
+
+# Annotation that marks a cluster as having had pre-upgrade backup taken
+PRE_UPGRADE_BACKUP_ANNOTATION = "odh.ray.io/pre-upgrade-backup-taken"
 
 # Gateway API constants
 GATEWAY_API_GROUP = "gateway.networking.k8s.io"
 GATEWAY_API_VERSION = "v1"
 
 
+def _confirm(prompt: str, auto_confirm: bool = False) -> bool:
+    """
+    Prompt for yes/no confirmation.
+
+    Returns:
+        True if the user confirmed (or auto_confirm), False otherwise.
+    """
+    if auto_confirm:
+        return True
+    response = input(prompt).strip().lower()
+    return response in ["yes", "y"]
+
+
 def config_check():
     """
-    Check and load the Kubernetes config from the default location.
+    Check and load the Kubernetes config.
 
-    This function checks if a Kubernetes config file exists at the default path
-    (~/.kube/config). If none is provided, it tries to load in-cluster config.
+    Resolution order:
+    1. KUBECONFIG environment variable (may contain multiple paths)
+    2. ~/.kube/config
+    3. In-cluster config (when running inside a Kubernetes pod)
 
     Raises:
         RuntimeError: If no valid credentials or config file is found.
     """
-    home_directory = os.path.expanduser("~")
-
-    # Try to load kube config if not already loaded
     try:
-        # First try to load from default location
-        if os.path.isfile(f"{home_directory}/.kube/config"):
-            config.load_kube_config()
-        # Then try in-cluster config
-        elif "KUBERNETES_PORT" in os.environ:
+        config.load_kube_config()
+    except config.ConfigException:
+        try:
             config.load_incluster_config()
-        else:
+        except config.ConfigException:
             raise RuntimeError(
                 "No Kubernetes configuration found. Please ensure you have a valid "
-                "~/.kube/config file or are running in a Kubernetes cluster."
+                "kubeconfig (via KUBECONFIG env var or ~/.kube/config) "
+                "or are running in a Kubernetes cluster."
             )
-    except config.ConfigException as e:
-        raise RuntimeError(f"Failed to load Kubernetes configuration: {e}")
 
 
 def get_api_client() -> client.ApiClient:
@@ -264,6 +297,228 @@ def _suspend_cluster(
         name=name,
         body=patch_body,
     )
+
+
+def _remove_pre_upgrade_backup_annotation(
+    api_instance, name: str, namespace: str
+) -> None:
+    """
+    Remove the pre-upgrade backup annotation from a RayCluster after successful migration.
+    No-op if the annotation is not present. Logs a warning on failure (non-fatal).
+    """
+    try:
+        rc = api_instance.get_namespaced_custom_object(
+            group="ray.io",
+            version="v1",
+            namespace=namespace,
+            plural="rayclusters",
+            name=name,
+        )
+        annotations = rc.get("metadata", {}).get("annotations") or {}
+        if PRE_UPGRADE_BACKUP_ANNOTATION not in annotations:
+            return
+        api_instance.patch_namespaced_custom_object(
+            group="ray.io",
+            version="v1",
+            namespace=namespace,
+            plural="rayclusters",
+            name=name,
+            body={"metadata": {"annotations": {PRE_UPGRADE_BACKUP_ANNOTATION: None}}},
+        )
+    except Exception as e:
+        print(
+            f"  Warning: could not remove pre-upgrade backup annotation from {name}: {e}"
+        )
+
+
+def _set_enable_ingress_false(api_instance, name: str, namespace: str) -> None:
+    """
+    Set spec.headGroupSpec.enableIngress to false on a RayCluster.
+    If the field is missing or not already false, it is added or updated to false.
+    Used during pre-upgrade so that when new KubeRay is deployed it picks up the change
+    immediately, without waiting for the user to run post-upgrade.
+    No-op if enableIngress is already false. Logs a warning on failure (non-fatal).
+    """
+    try:
+        rc = api_instance.get_namespaced_custom_object(
+            group="ray.io",
+            version="v1",
+            namespace=namespace,
+            plural="rayclusters",
+            name=name,
+        )
+        head_spec = (rc.get("spec") or {}).get("headGroupSpec") or {}
+        if head_spec.get("enableIngress") is False:
+            return
+        was_true = head_spec.get("enableIngress") is True
+        if was_true:
+            print(
+                f"  [{name}] enableIngress was true; setting to false. "
+                "Post RHOAI migration the existing route will be removed in favour of Gateway API access."
+            )
+        api_instance.patch_namespaced_custom_object(
+            group="ray.io",
+            version="v1",
+            namespace=namespace,
+            plural="rayclusters",
+            name=name,
+            body={"spec": {"headGroupSpec": {"enableIngress": False}}},
+        )
+    except Exception as e:
+        print(f"  Warning: could not set enableIngress to false for {name}: {e}")
+
+
+def _is_route_owned_by_ray_cluster(route: dict) -> bool:
+    """
+    Return True if the Route has an ownerReference to a RayCluster (ray.io/v1).
+    """
+    refs = route.get("metadata", {}).get("ownerReferences") or []
+    for ref in refs:
+        if ref.get("kind") == "RayCluster" and (
+            ref.get("apiVersion") == "ray.io/v1"
+            or (ref.get("apiVersion") or "").endswith("ray.io/v1")
+        ):
+            return True
+    return False
+
+
+def _collect_ray_owned_routes(
+    api_instance, namespaces: List[str]
+) -> List[Tuple[str, str]]:
+    """
+    List OpenShift Routes in the given namespaces that have an ownerReference
+    to a RayCluster (ray.io/v1).
+
+    Returns:
+        [(namespace, route_name), ...]
+    """
+    owned = []
+    for ns in namespaces:
+        if not ns:
+            continue
+        try:
+            resp = api_instance.list_namespaced_custom_object(
+                group="route.openshift.io",
+                version="v1",
+                namespace=ns,
+                plural="routes",
+            )
+        except ApiException as e:
+            if e.status == 404 or "Unknown" in (e.reason or ""):
+                continue
+            if e.status == 403:
+                continue
+            raise
+        for route in resp.get("items", []):
+            if not _is_route_owned_by_ray_cluster(route):
+                continue
+            name = route.get("metadata", {}).get("name")
+            if name:
+                owned.append((ns, name))
+    return owned
+
+
+def _wait_for_no_ray_owned_routes(
+    api_instance,
+    namespaces: List[str],
+    timeout_seconds: int = 120,
+    poll_interval: int = 3,
+) -> bool:
+    """
+    Poll until no Ray-owned OpenShift Routes remain in the given namespaces.
+    Re-deletes routes if the operator recreates them while enableIngress settles.
+
+    Returns:
+        True if no Ray-owned routes remain, False on timeout.
+    """
+    elapsed = 0
+    logged_waiting = False
+
+    while elapsed < timeout_seconds:
+        remaining = _collect_ray_owned_routes(api_instance, namespaces)
+        if not remaining:
+            if logged_waiting:
+                print("  Ray-owned Routes removed.")
+            return True
+
+        if not logged_waiting:
+            print("Pre-upgrade step: Waiting for Ray-owned Routes to be removed...")
+            logged_waiting = True
+
+        for ns, name in remaining:
+            try:
+                api_instance.delete_namespaced_custom_object(
+                    group="route.openshift.io",
+                    version="v1",
+                    namespace=ns,
+                    plural="routes",
+                    name=name,
+                )
+            except ApiException as e:
+                if e.status != 404:
+                    print(f"  Warning: could not delete Route {ns}/{name}: {e.reason}")
+
+        time.sleep(poll_interval)
+        elapsed += poll_interval
+
+    remaining = _collect_ray_owned_routes(api_instance, namespaces)
+    print(
+        f"  Warning: timed out after {timeout_seconds}s waiting for Ray-owned "
+        "Routes to be removed:"
+    )
+    for ns, name in remaining:
+        print(f"    - {ns}/{name}")
+    return False
+
+
+def _delete_routes_owned_by_ray_clusters(
+    api_instance, namespaces: List[str]
+) -> Tuple[int, List[Tuple[str, str]]]:
+    """
+    In each given namespace, list OpenShift Routes and delete any that have an
+    ownerReference to a RayCluster (ray.io/v1). Used during pre-upgrade so the
+    old enableIngress-created Route is removed before the RHOAI upgrade.
+
+    Returns:
+        (deleted_count, [(namespace, route_name), ...])
+    """
+    deleted = []
+    for ns in namespaces:
+        if not ns:
+            continue
+        try:
+            resp = api_instance.list_namespaced_custom_object(
+                group="route.openshift.io",
+                version="v1",
+                namespace=ns,
+                plural="routes",
+            )
+        except ApiException as e:
+            if e.status == 404 or "Unknown" in (e.reason or ""):
+                continue
+            if e.status == 403:
+                continue
+            raise
+        items = resp.get("items", [])
+        for route in items:
+            if not _is_route_owned_by_ray_cluster(route):
+                continue
+            name = route.get("metadata", {}).get("name")
+            if not name:
+                continue
+            try:
+                api_instance.delete_namespaced_custom_object(
+                    group="route.openshift.io",
+                    version="v1",
+                    namespace=ns,
+                    plural="routes",
+                    name=name,
+                )
+                deleted.append((ns, name))
+            except ApiException as e:
+                if e.status != 404:
+                    print(f"  Warning: could not delete Route {ns}/{name}: {e.reason}")
+    return len(deleted), deleted
 
 
 def _wait_for_cluster_suspended(
@@ -706,14 +961,20 @@ def _get_cluster_route(
                 print(f"    [DEBUG] Cluster-wide search failed: {e}")
             pass  # Will fall through to namespace search
 
-        # If cluster-wide search didn't find anything, try namespace-specific search
+        # If cluster-wide search didn't find anything, try namespace-specific search.
+        # HTTPRoutes are created in the RayCluster namespace; search it first when known.
         if not httproute:
-            search_namespaces = [
-                "redhat-ods-applications",
-                "opendatahub",
-                "default",
-                "ray-system",
-            ]
+            search_namespaces = list(
+                dict.fromkeys(
+                    ([namespace] if namespace else [])
+                    + [
+                        "redhat-ods-applications",
+                        "opendatahub",
+                        "default",
+                        "ray-system",
+                    ]
+                )
+            )
 
             for ns in search_namespaces:
                 try:
@@ -753,7 +1014,9 @@ def _get_cluster_route(
 
         gateway_ref = parent_refs[0]
         gateway_name = gateway_ref.get("name")
-        gateway_namespace = gateway_ref.get("namespace")
+        # parentRefs[].namespace is optional; defaults to the HTTPRoute's namespace.
+        route_namespace = (httproute.get("metadata") or {}).get("namespace")
+        gateway_namespace = gateway_ref.get("namespace") or route_namespace
 
         if not gateway_name or not gateway_namespace:
             return None
@@ -886,65 +1149,100 @@ def _check_cert_manager_installed(api_client) -> Tuple[bool, str]:
     return False, "cert-manager not detected"
 
 
-def _check_codeflare_operator_status(api_client) -> Tuple[bool, str]:
+def _set_dsc_codeflare_removed(api_client) -> Tuple[bool, str]:
     """
-    Check if the codeflare-operator is set to Removed or not present in the DataScienceCluster.
+    Set the codeflare component to Removed in the DataScienceCluster (if present and not already Removed).
+    Performed as part of pre-upgrade so the user does not need to do this step manually.
 
     Returns:
-        Tuple[bool, str]: (is_removed_or_not_present, message)
+        Tuple[bool, str]: (success, message)
     """
     try:
         custom_api = client.CustomObjectsApi(api_client)
-
-        # List DataScienceClusters
         dscs = custom_api.list_cluster_custom_object(
             group="datasciencecluster.opendatahub.io",
             version="v1",
             plural="datascienceclusters",
         )
-
         if not dscs.get("items"):
-            return True, "No DataScienceCluster found (OK to proceed)"
+            return True, "No DataScienceCluster found (nothing to update)."
 
-        # Check the first DSC (typically there's only one)
         dsc = dscs["items"][0]
         dsc_name = dsc.get("metadata", {}).get("name", "unknown")
-
-        # Check if codeflare component exists in the DSC
+        dsc_namespace = (dsc.get("metadata") or {}).get("namespace", "")
         components = dsc.get("spec", {}).get("components", {})
 
         if "codeflare" not in components:
-            # codeflare not present in DSC - this is OK (common after RHOAI 3.x upgrade)
-            return True, f"codeflare not present in DSC '{dsc_name}' (OK to proceed)"
-
-        # Get codeflare managementState from spec
-        codeflare_state = components.get("codeflare", {}).get("managementState", "")
-
-        if codeflare_state.lower() == "removed":
-            return True, f"codeflare is Removed in DSC '{dsc_name}'"
-        elif codeflare_state.lower() == "unmanaged":
-            return True, f"codeflare is Unmanaged in DSC '{dsc_name}'"
-        elif codeflare_state.lower() == "managed":
-            return (
-                False,
-                f"codeflare is Managed in DSC '{dsc_name}' (should be Removed)",
-            )
-        elif not codeflare_state:
-            # codeflare entry exists but managementState not set - treat as OK
             return (
                 True,
-                f"codeflare present without managementState in DSC '{dsc_name}' (OK to proceed)",
+                f"Codeflare not present in DataScienceCluster '{dsc_name}' (nothing to update).",
+            )
+
+        codeflare_state = (components.get("codeflare") or {}).get("managementState", "")
+        if (codeflare_state or "").lower() == "removed":
+            return (
+                True,
+                f"Codeflare is already Removed in DataScienceCluster '{dsc_name}'.",
+            )
+
+        patch = {"spec": {"components": {"codeflare": {"managementState": "Removed"}}}}
+        if dsc_namespace:
+            custom_api.patch_namespaced_custom_object(
+                group="datasciencecluster.opendatahub.io",
+                version="v1",
+                namespace=dsc_namespace,
+                plural="datascienceclusters",
+                name=dsc_name,
+                body=patch,
             )
         else:
-            return False, f"codeflare is '{codeflare_state}' in DSC '{dsc_name}'"
+            custom_api.patch_cluster_custom_object(
+                group="datasciencecluster.opendatahub.io",
+                version="v1",
+                plural="datascienceclusters",
+                name=dsc_name,
+                body=patch,
+            )
+        return True, f"Set codeflare to Removed in DataScienceCluster '{dsc_name}'."
+    except ApiException as e:
+        return False, f"Failed to set codeflare to Removed: {e.reason}"
+    except Exception as e:
+        return False, f"Failed to set codeflare to Removed: {str(e)}"
 
+
+def _check_rayclusters_present(api_client) -> Tuple[bool, str]:
+    """
+    Report how many RayClusters exist on the cluster (cluster-wide).
+    When none are found, the message explicitly tells the user they do not need
+    to run any Ray migration steps.
+
+    Returns:
+        Tuple[bool, str]: (always True, informational message)
+    """
+    try:
+        custom_api = client.CustomObjectsApi(api_client)
+        result = custom_api.list_cluster_custom_object(
+            group="ray.io",
+            version="v1",
+            plural="rayclusters",
+        )
+        items = result.get("items", [])
+        count = len(items)
+        if count == 0:
+            return (
+                True,
+                "No RayClusters on cluster — no Ray migration required for this upgrade.",
+            )
+        return True, f"{count} RayCluster(s) on cluster."
     except ApiException as e:
         if e.status == 404:
-            return True, "DataScienceCluster CRD not found (OK to proceed)"
-        else:
-            return True, f"Could not check DataScienceCluster (skipping): {e.reason}"
+            return (
+                True,
+                "No RayClusters on cluster (RayCluster CRD not installed) — no Ray migration required.",
+            )
+        return True, f"Could not list RayClusters (skipping): {e.reason}"
     except Exception as e:
-        return True, f"Could not check DataScienceCluster (skipping): {str(e)}"
+        return True, f"Could not list RayClusters (skipping): {str(e)}"
 
 
 def _check_permission(
@@ -1007,9 +1305,25 @@ def _run_pre_upgrade_checks(api_client) -> List[Dict[str, any]]:
     # Permission checks for pre-upgrade
     permission_checks = [
         ("list", "namespaces", "", "List namespaces"),
+        ("get", "namespaces", "", "Get namespaces"),
         ("list", "rayclusters", "ray.io", "List RayClusters"),
         ("get", "rayclusters", "ray.io", "Get RayClusters"),
-        ("update", "rayclusters", "ray.io", "Update RayClusters"),
+        ("patch", "rayclusters", "ray.io", "Patch RayClusters"),
+        ("list", "routes", "route.openshift.io", "List Routes"),
+        ("delete", "routes", "route.openshift.io", "Delete Routes"),
+        (
+            "list",
+            "datascienceclusters",
+            "datasciencecluster.opendatahub.io",
+            "List DataScienceClusters",
+        ),
+        (
+            "patch",
+            "datascienceclusters",
+            "datasciencecluster.opendatahub.io",
+            "Patch DataScienceClusters",
+        ),
+        ("get", "customresourcedefinitions", "apiextensions.k8s.io", "Get CRDs"),
     ]
 
     all_permissions_ok = True
@@ -1026,7 +1340,7 @@ def _run_pre_upgrade_checks(api_client) -> List[Dict[str, any]]:
             "name": "Permissions",
             "passed": all_permissions_ok,
             "message": (
-                "All required permissions granted"
+                "All required permissions to perform the ray upgrade are available to this user."
                 if all_permissions_ok
                 else "Missing permissions"
             ),
@@ -1054,17 +1368,15 @@ def _run_pre_upgrade_checks(api_client) -> List[Dict[str, any]]:
         }
     )
 
-    # Check codeflare-operator status in DSC
-    codeflare_ok, codeflare_msg = _check_codeflare_operator_status(api_client)
+    # Informational last: how many RayClusters exist (and that none = no migration needed)
+    rayclusters_ok, rayclusters_msg = _check_rayclusters_present(api_client)
     checks.append(
         {
-            "name": "codeflare-operator",
-            "passed": codeflare_ok,
-            "message": codeflare_msg,
-            "required": True,
-            "help": "Set codeflare to Removed in your DataScienceCluster before upgrading: "
-            "oc patch datasciencecluster <name> --type merge -p "
-            '\'{"spec":{"components":{"codeflare":{"managementState":"Removed"}}}}\'',
+            "name": "RayClusters",
+            "passed": rayclusters_ok,
+            "message": rayclusters_msg,
+            "required": False,
+            "help": "",
         }
     )
 
@@ -1214,10 +1526,7 @@ def _post_upgrade_from_backup(
         print("  - All running pods, jobs, and workloads will be terminated.")
         print("  - Existing job state and logs will be lost.")
         print("  - The cluster will be recreated from the backup configuration.")
-        response = (
-            input("\nProceed with restore from backup? (yes/no): ").strip().lower()
-        )
-        if response not in ["yes", "y"]:
+        if not _confirm("\nProceed with restore from backup? (yes/no): ", auto_confirm):
             print("Restore cancelled.")
             return {"migrated": 0, "skipped": 0, "failed": 0}
         print()
@@ -1311,28 +1620,52 @@ def _post_upgrade_from_backup(
                 body=doc,
             )
 
-            # Wait for cluster to become ready
-            print(f"  [{name}] Waiting for cluster to become ready...")
-            cluster_ready = _wait_for_cluster_ready(
-                api_instance, core_api, name, ns, timeout_seconds=300
-            )
+            # Check if cluster is suspended - suspended clusters don't need readiness check
+            is_suspended = doc.get("spec", {}).get("suspend", False)
 
-            if cluster_ready:
-                # Cluster is ready, get the route URL
-                route_url = _get_cluster_route(api_instance, name, ns)
+            if is_suspended:
+                # Suspended clusters don't have pods, so skip pod readiness check
+                print(f"  [OK] Restored from backup: {name} (ns: {ns}) [SUSPENDED]")
+                print(
+                    "       Note: Suspended clusters may become active after restore."
+                )
+                print("       Verify cluster state and re-suspend if needed.")
+                if not dry_run:
+                    _remove_pre_upgrade_backup_annotation(api_instance, name, ns)
+                migrated_count += 1
+                successfully_migrated.append({"name": name, "namespace": ns})
+            else:
+                # Wait for route to be available (indicates operator has reconciled)
+                print(f"  [{name}] Waiting for route to become available...")
+                route_url = None
+                route_timeout = 90  # seconds
+                route_poll_interval = 5
+                route_elapsed = 0
+
+                while route_elapsed < route_timeout:
+                    route_url = _get_cluster_route(api_instance, name, ns)
+                    if route_url:
+                        break
+                    time.sleep(route_poll_interval)
+                    route_elapsed += route_poll_interval
+
                 if route_url:
                     print(f"  [OK] Restored from backup: {name} (ns: {ns})")
                     print(f"       Dashboard: {route_url}")
+                    print(
+                        "       Pods will become ready when quota/resources are available."
+                    )
                 else:
                     print(f"  [OK] Restored from backup: {name} (ns: {ns})")
                     print("       Dashboard: Route not yet available (check later)")
-            else:
-                print(
-                    f"  [OK] Restored from backup: {name} (ns: {ns}) - cluster starting up"
-                )
+                    print(
+                        "       Pods will become ready when quota/resources are available."
+                    )
 
-            migrated_count += 1
-            successfully_migrated.append({"name": name, "namespace": ns})
+                if not dry_run:
+                    _remove_pre_upgrade_backup_annotation(api_instance, name, ns)
+                migrated_count += 1
+                successfully_migrated.append({"name": name, "namespace": ns})
 
         except Exception as e:
             print(f"  [FAIL] {name} (ns: {ns}): {e}")
@@ -1347,12 +1680,13 @@ def _post_upgrade_from_backup(
         print("Restore from Backup Summary:")
         print(f"  Restored: {migrated_count}")
     print(f"  Failed: {failed_count}")
+    if failed_count:
+        print("  Please verify failed clusters and revisit as needed.")
 
     return {"restored": migrated_count, "skipped": 0, "failed": failed_count}
 
 
 def pre_upgrade(
-    output_dir: Optional[str] = None,
     cluster_name: Optional[str] = None,
     namespace: Optional[str] = None,
 ) -> List[str]:
@@ -1365,34 +1699,37 @@ def pre_upgrade(
 
     It does NOT delete any clusters - it only creates backup files.
 
+    Backup files are saved to $RHOAI_UPGRADE_BACKUP_DIR/ray/ (default: /tmp/rhoai-upgrade-backup/ray/)
+    with subdirectories for rhoai-2.x and rhoai-3.x compatible configurations.
+
     This operation is idempotent - running it multiple times will simply
     overwrite the backup files.
 
     Args:
-        output_dir: Directory to save backup YAML files (prompts if not provided)
         cluster_name: Specific cluster to backup (requires namespace)
         namespace: Specific namespace to backup (optional)
 
     Returns:
         List[str]: List of backup file paths created
     """
-    # Prompt for output directory if not provided
-    if not output_dir:
-        default_dir = "./raycluster-backups"
-        user_input = input(f"Enter backup directory [{default_dir}]: ").strip()
-        output_dir = user_input if user_input else default_dir
-        print()
+    print("Starting Ray cluster pre-upgrade...")
+    print()
 
+    output_dir = os.path.join(RHOAI_UPGRADE_BACKUP_DIR, "ray")
+
+    print("Connecting to Kubernetes cluster...")
     try:
         config_check()
     except Exception as e:
         raise RuntimeError(f"Failed to connect to Kubernetes cluster: {e}")
+    print("Connected.")
+    print()
 
     api_client = get_api_client()
     api_instance = client.CustomObjectsApi(api_client)
     core_api = client.CoreV1Api(api_client)
 
-    # Run pre-flight checks
+    # Run pre-flight checks before making any cluster modifications
     print("Running pre-upgrade checks...")
     print("-" * 60)
 
@@ -1420,21 +1757,75 @@ def pre_upgrade(
 
     if has_required_failures:
         print("\nPre-upgrade checks failed. Please resolve the issues above before")
-        print("proceeding with the RHOAI upgrade.")
+        print("proceeding with the ray pre-upgrade steps.")
         print()
         print(
-            "WARNING: Proceeding with the RHOAI upgrade without resolving these issues"
+            "CRITICAL: Proceeding with the RHOAI upgrade without resolving these issues"
         )
         print(
             "may result in your Ray infrastructure becoming unavailable or unrecoverable."
         )
-        return []
+        sys.exit(1)
     elif all_passed:
         print("All pre-upgrade checks passed.\n")
     else:
         print("Pre-upgrade checks completed with warnings.\n")
 
-    # Create output directory if it doesn't exist
+    # Set codeflare to Removed in DataScienceCluster (only after all required checks pass)
+    print("Pre-upgrade step: Setting codeflare to Removed in DataScienceCluster...")
+    codeflare_ok, codeflare_msg = _set_dsc_codeflare_removed(api_client)
+    print(f"  {codeflare_msg}")
+    if not codeflare_ok:
+        print(
+            "  WARNING: Could not update DataScienceCluster. You may need to set codeflare to Removed manually before the RHOAI upgrade."
+        )
+    print()
+
+    # Get clusters based on scope (before creating output directory)
+    clusters = _get_clusters(api_instance, core_api, cluster_name, namespace)
+
+    if not clusters:
+        print("No RayClusters were found in the specified scope.")
+        print(
+            "You do not need to run any post-upgrade Ray migration steps for this RHOAI upgrade."
+        )
+        return []
+
+    namespaces_with_ray = list(
+        {rc.get("metadata", {}).get("namespace") for rc in clusters}
+    )
+
+    # Disable enableIngress before deleting Routes so KubeRay does not recreate them
+    # during the backup phase on a slow/fresh cluster.
+    print("Pre-upgrade step: Setting enableIngress to false on RayClusters...")
+    for rc in clusters:
+        name = rc.get("metadata", {}).get("name", "unknown")
+        ns = rc.get("metadata", {}).get("namespace", "unknown")
+        _set_enable_ingress_false(api_instance, name, ns)
+    print()
+
+    # Remove OpenShift Routes owned by RayClusters (from enableIngress);
+    # post-upgrade uses Gateway API instead.
+    try:
+        n_removed, removed_routes = _delete_routes_owned_by_ray_clusters(
+            api_instance, namespaces_with_ray
+        )
+        if n_removed:
+            print("Pre-upgrade step: Removed OpenShift Route(s) owned by RayClusters:")
+            for ns, rname in removed_routes:
+                print(f"  - {ns}/{rname}")
+            print()
+    except Exception as e:
+        print(f"  Warning: could not remove Routes owned by RayClusters: {e}")
+        print()
+
+    _wait_for_no_ray_owned_routes(api_instance, namespaces_with_ray)
+    print()
+
+    print(f"Backup files will be saved to: {output_dir}")
+    print()
+
+    # Create output directory if it doesn't exist (only when we have clusters to backup)
     if not os.path.exists(output_dir):
         try:
             os.makedirs(output_dir)
@@ -1444,24 +1835,7 @@ def pre_upgrade(
             print(
                 "Please check that you have write permissions to the parent directory."
             )
-            return []
-
-    # Get clusters based on scope
-    clusters = _get_clusters(api_instance, core_api, cluster_name, namespace)
-
-    if not clusters:
-        print("No RayClusters found to backup")
-        return []
-
-    # Describe the scope
-    if cluster_name:
-        scope_msg = f"cluster '{cluster_name}' in namespace '{namespace}'"
-    elif namespace:
-        scope_msg = f"all clusters in namespace '{namespace}'"
-    else:
-        scope_msg = "all clusters across all namespaces"
-
-    print(f"\nBacking up {len(clusters)} RayCluster(s) ({scope_msg})\n")
+            sys.exit(1)
 
     # Create subdirectories for RHOAI 2.x and 3.x compatible backups
     rhoai_2x_dir = os.path.join(output_dir, "rhoai-2.x")
@@ -1473,7 +1847,7 @@ def pre_upgrade(
                 os.makedirs(subdir)
             except OSError as e:
                 print(f"ERROR: Failed to create backup subdirectory '{subdir}': {e}")
-                return []
+                sys.exit(1)
 
     saved_files = []
 
@@ -1506,7 +1880,28 @@ def pre_upgrade(
                 yaml.dump(rc_3x, outfile, default_flow_style=False)
 
             saved_files.append(rhoai_3x_filename)
-            print(f"  Backed up: {name} (namespace: {ns})")
+
+            # Mark RayCluster as having had pre-upgrade backup taken
+            try:
+                timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                annotations = dict(rc.get("metadata", {}).get("annotations") or {})
+                annotations[PRE_UPGRADE_BACKUP_ANNOTATION] = timestamp
+                api_instance.patch_namespaced_custom_object(
+                    group="ray.io",
+                    version="v1",
+                    namespace=ns,
+                    plural="rayclusters",
+                    name=name,
+                    body={"metadata": {"annotations": annotations}},
+                )
+            except Exception as patch_err:
+                print(
+                    f"  Warning: could not add pre-upgrade annotation to {name}: {patch_err}"
+                )
+
+            # Set enableIngress to false so new KubeRay picks it up immediately after upgrade,
+            # without relying on the user running post-upgrade right away.
+            _set_enable_ingress_false(api_instance, name, ns)
 
         except Exception as e:
             name = rc.get("metadata", {}).get("name", "unknown")
@@ -1514,23 +1909,12 @@ def pre_upgrade(
             continue
 
     print(f"\nBackup complete: {len(saved_files)} RayCluster(s) saved to {output_dir}")
-    print("\nBackup directory structure:")
-    print(f"  {output_dir}/")
-    print(
-        "    rhoai-2.x/  - RHOAI 2.x compatible (use if you did not proceed with the 3.x upgrade)"
-    )
-    print(
-        "    rhoai-3.x/  - RHOAI 3.x compatible (use with post-upgrade --from-backup)"
-    )
-    print()
-    print("WARNING: The 'rhoai-2.x/' backups contain CodeFlare-operator components.")
+    print("\nINFO: The 'rhoai-2.x/' backups contain CodeFlare-operator components.")
     print(
         "         Use 'rhoai-2.x/' ONLY if attempting to restore RayClusters but did not proceed with the RHOAI 3.x upgrade."
     )
     print("         Use 'rhoai-3.x/' for proceeding with the RHOAI 3.x upgrade.")
-    print("\nNext steps:")
-    print("  1. Perform the RHOAI upgrade")
-    print("  2. Run 'post-upgrade' to migrate the RayClusters")
+    print("\nRay Pre Upgrade Steps Completed.")
     return saved_files
 
 
@@ -1657,6 +2041,9 @@ def post_upgrade(
                 print(
                     "WARNING: You are about to migrate ALL clusters across ALL namespaces"
                 )
+            print(
+                "Ensure the upgraded RHOAI dashboard is fully rolled out and available."
+            )
             print("=" * 60)
 
         print(f"\nThe following {len(to_migrate)} cluster(s) will be migrated:")
@@ -1667,15 +2054,18 @@ def post_upgrade(
             "\nIMPORTANT: Migration will cause temporary downtime for each RayCluster."
         )
         print(
-            "  - Pods will be restarted as the KubeRay operator recreates them with the new configuration."
+            "  - Pods will be restarted as the KubeRay operator recreates them with the updated configuration."
         )
         print("  - Existing job state and logs will be lost.")
         print(
             "  - Currently running workloads/jobs will be interrupted and progress lost."
         )
+        print(
+            "  - Kueue-managed suspended RayClusters may become active after migration, potentially"
+        )
+        print("    affecting quota. Re-suspend workloads manually if needed.")
 
-        response = input("\nProceed with migration? (yes/no): ").strip().lower()
-        if response not in ["yes", "y"]:
+        if not _confirm("\nProceed with migration? (yes/no): ", auto_confirm):
             print("Migration cancelled.")
             return {"migrated": 0, "skipped": len(already_migrated), "failed": 0}
         print()
@@ -1768,27 +2158,53 @@ def post_upgrade(
             )
 
             # Step 4: Wait for cluster to become ready (KubeRay handles pod recreation)
-            print(f"  [{name}] Waiting for cluster to become ready...")
-            cluster_ready = _wait_for_cluster_ready(
-                api_instance, core_api, name, ns, timeout_seconds=300
-            )
+            # Check if cluster is suspended - suspended clusters don't need readiness check
+            is_suspended = rc.get("spec", {}).get("suspend", False)
 
-            if cluster_ready:
-                # Cluster is ready, get the route URL
-                route_url = _get_cluster_route(api_instance, name, ns)
+            if is_suspended:
+                # Suspended clusters don't have pods, so skip pod readiness check
+                # Route will be created by the operator when the cluster is unsuspended
+                print(f"  [OK] Migrated: {name} (ns: {ns}) [SUSPENDED]")
+                print(
+                    "       Note: Suspended clusters may become active after migration."
+                )
+                print("       Verify cluster state and re-suspend if needed.")
+                if not dry_run:
+                    _remove_pre_upgrade_backup_annotation(api_instance, name, ns)
+                migrated_count += 1
+                successfully_migrated.append({"name": name, "namespace": ns})
+            else:
+                # Wait for route to be available (indicates operator has reconciled)
+                print(f"  [{name}] Waiting for route to become available...")
+                route_url = None
+                route_timeout = 90  # seconds
+                route_poll_interval = 5
+                route_elapsed = 0
+
+                while route_elapsed < route_timeout:
+                    route_url = _get_cluster_route(api_instance, name, ns)
+                    if route_url:
+                        break
+                    time.sleep(route_poll_interval)
+                    route_elapsed += route_poll_interval
+
                 if route_url:
                     print(f"  [OK] Migrated: {name} (ns: {ns})")
                     print(f"       Dashboard: {route_url}")
+                    print(
+                        "       Pods will become ready when quota/resources are available."
+                    )
                 else:
                     print(f"  [OK] Migrated: {name} (ns: {ns})")
                     print("       Dashboard: Route not yet available (check later)")
-            else:
-                print(
-                    f"  [OK] Migrated: {name} (ns: {ns}) - cluster starting up (may take a moment)"
-                )
+                    print(
+                        "       Pods will become ready when quota/resources are available."
+                    )
 
-            migrated_count += 1
-            successfully_migrated.append({"name": name, "namespace": ns})
+                if not dry_run:
+                    _remove_pre_upgrade_backup_annotation(api_instance, name, ns)
+                migrated_count += 1
+                successfully_migrated.append({"name": name, "namespace": ns})
 
         except Exception as e:
             print(f"  [FAIL] {name} (ns: {ns}): {e}")
@@ -1804,6 +2220,8 @@ def post_upgrade(
         print(f"  Migrated: {migrated_count}")
     print(f"  Skipped (already migrated): {len(already_migrated)}")
     print(f"  Failed: {failed_count}")
+    if failed_count:
+        print("  Please verify failed clusters and revisit as needed.")
 
     return {
         "migrated": migrated_count,
@@ -1879,8 +2297,10 @@ def list_ray_clusters(
                 "memory_limit": head_spec.get("limits", {}).get("memory", "N/A"),
             }
 
-            worker_spec = rc["spec"]["workerGroupSpecs"][0]
-            num_workers = worker_spec.get("replicas", 0)
+            worker_group_specs = rc["spec"]["workerGroupSpecs"]
+            num_workers = sum(ws.get("replicas", 0) for ws in worker_group_specs)
+            # Use first worker group for resource display (when multiple groups, resources may differ)
+            worker_spec = worker_group_specs[0]
             worker_container_resources = worker_spec["template"]["spec"]["containers"][
                 0
             ]["resources"]
@@ -1924,7 +2344,7 @@ def list_ray_clusters(
     else:
         print("RayCluster Migration Status:\n")
         print(
-            f"{'Name':<25} {'Namespace':<18} {'Status':<12} {'Workers':<8} {'Migration Status':<30}"
+            f"{'RayCluster Name':<25} {'Namespace':<18} {'Status':<12} {'Workers':<8} {'Migration Status':<30}"
         )
         print("-" * 100)
 
@@ -2012,8 +2432,7 @@ def delete_ray_clusters(
             print(f"  - {name} (namespace: {ns})")
 
         print("\nThis operation is IRREVERSIBLE!")
-        response = input("\nDelete these clusters? (yes/no): ").strip().lower()
-        if response not in ["yes", "y"]:
+        if not _confirm("\nDelete these clusters? (yes/no): ", auto_confirm):
             print("Delete cancelled.")
             return {"deleted": 0, "failed": 0}
         print()
@@ -2203,11 +2622,8 @@ RECOMMENDED MIGRATION WORKFLOW:
 
   1. BEFORE UPGRADE - Backup your clusters:
 
-     # Backup all clusters (you'll be prompted for backup directory)
+     # Backup all clusters
      %(prog)s pre-upgrade
-
-     # Or specify the backup directory directly
-     %(prog)s pre-upgrade ./my-backup-dir
 
      # Backup a specific namespace
      %(prog)s pre-upgrade --namespace my-ns
@@ -2215,7 +2631,9 @@ RECOMMENDED MIGRATION WORKFLOW:
      # Backup a single cluster
      %(prog)s pre-upgrade --cluster my-cluster --namespace my-ns
 
-  2. PERFORM THE RHOAI UPGRADE
+     Backups are saved to $RHOAI_UPGRADE_BACKUP_DIR/ray/ (default: /tmp/rhoai-upgrade-backup/ray/)
+
+   2. PERFORM THE RHOAI UPGRADE
 
   3. AFTER UPGRADE - Migrate your clusters:
 
@@ -2246,13 +2664,8 @@ All operations are idempotent and safe to run multiple times.
         "pre-upgrade",
         help="Backup RayCluster configurations BEFORE the RHOAI upgrade",
         description="Runs pre-flight checks and creates backup YAML files of your "
-        "RayCluster configurations. Run this BEFORE performing the RHOAI upgrade.",
-    )
-    pre_parser.add_argument(
-        "output_dir",
-        nargs="?",
-        default=None,
-        help="Directory to save backup YAML files (you'll be prompted if not provided)",
+        "RayCluster configurations. Run this BEFORE performing the RHOAI upgrade. "
+        "Backups are saved to $RHOAI_UPGRADE_BACKUP_DIR/ray/ (default: /tmp/rhoai-upgrade-backup/ray/).",
     )
     pre_parser.add_argument(
         "--cluster",
@@ -2387,18 +2800,19 @@ All operations are idempotent and safe to run multiple times.
     try:
         if args.command == "pre-upgrade":
             pre_upgrade(
-                output_dir=args.output_dir,
                 cluster_name=args.cluster_name,
                 namespace=args.namespace,
             )
         elif args.command == "post-upgrade":
-            post_upgrade(
+            result = post_upgrade(
                 cluster_name=args.cluster_name,
                 namespace=args.namespace,
                 dry_run=args.dry_run,
                 auto_confirm=args.yes,
                 from_backup=args.from_backup,
             )
+            if result.get("failed", 0) > 0:
+                sys.exit(1)
         elif args.command == "list":
             list_ray_clusters(namespace=args.namespace, output_format=args.format)
         elif args.command == "delete":

--- a/tests/e2e/support.py
+++ b/tests/e2e/support.py
@@ -1,3 +1,4 @@
+import json
 import os
 import random
 import string
@@ -616,24 +617,35 @@ def is_byoidc_cluster_detected():
 
         spec = auth_resource.get("spec", {})
 
-        # Any non-empty spec.oidcProviders.issuerURL means external OIDC is configured.
-        # This field is only populated on BYOIDC clusters — never on standard OAuth clusters.
+        # BYOIDC clusters register Authentication.spec.type as OIDC
+        if (spec.get("type") or "").upper() == "OIDC":
+            print("Detected BYOIDC cluster: Authentication spec.type is OIDC")
+            return True
+
+        # Check oidcProviders for Keycloak / QE BYOIDC issuer URLs
         if "oidcProviders" in spec and spec["oidcProviders"]:
             for provider in spec["oidcProviders"]:
                 issuer_url = provider.get("issuer", {}).get("issuerURL", "")
-                if issuer_url:
+                if "keycloak" in issuer_url.lower() and (
+                    "rh-ods.com" in issuer_url or "qe.rh-ods.com" in issuer_url
+                ):
                     print(f"Detected BYOIDC cluster with OIDC issuer: {issuer_url}")
                     return True
 
-        # Check webhookTokenAuthenticators
-        if "webhookTokenAuthenticators" in spec and spec["webhookTokenAuthenticators"]:
+        # Check webhookTokenAuthenticators (external OIDC token review)
+        if spec.get("webhookTokenAuthenticators"):
             for webhook in spec["webhookTokenAuthenticators"]:
                 if webhook.get("kubeConfig", {}):
                     print("Detected BYOIDC cluster with webhook token authenticator")
                     return True
 
-        # Do NOT check status.oidcClients — it is present on standard OpenShift 4.14+
-        # clusters too and causes false positives.
+        # status.oidcClients with componentName "cli" is NOT BYOIDC-specific (false positive
+        # on standard OpenShift). BYOIDC registers client id "oc-cli" — see run-tests.sh.
+        status = auth_resource.get("status", {})
+        oidc_clients_blob = json.dumps(status.get("oidcClients", []))
+        if "oc-cli" in oidc_clients_blob:
+            print("Detected BYOIDC cluster from status.oidcClients (oc-cli client)")
+            return True
 
         print("No BYOIDC indicators found in cluster Authentication resource")
         return False

--- a/tests/upgrade/00_ray_migration_post_upgrade_finalize_test.py
+++ b/tests/upgrade/00_ray_migration_post_upgrade_finalize_test.py
@@ -1,0 +1,42 @@
+# Copyright 2024 IBM, Red Hat
+#
+# First post_upgrade step: migrate the qualification RayCluster after RHOAI OLM upgrade.
+
+import pytest
+
+from tests.upgrade.constants import CLUSTER_NAME, NAMESPACE
+from tests.upgrade.migration_support import (
+    assert_raycluster_migrated_if_present,
+    assert_raycluster_ready_after_post_upgrade,
+    run_migration_post_upgrade,
+)
+
+
+@pytest.mark.post_upgrade
+class TestRayMigrationPostUpgradeFinalize:
+    """
+    First test in the post_upgrade suite (see conftest collection ordering).
+
+    Invokes ray_cluster_migration.py post-upgrade for the seeded mnist cluster.
+    Skips clusters already migrated (3.x→3.x). Required before job/UI post tests
+    when upgrading from 2.x with legacy TLS/OAuth on the RayCluster CR.
+    """
+
+    def test_ray_migration_post_upgrade_finalize(self):
+        result = run_migration_post_upgrade(
+            namespace=NAMESPACE,
+            cluster_name=CLUSTER_NAME,
+        )
+
+        assert result.returncode == 0, (
+            f"Migration post-upgrade exited with code {result.returncode}; "
+            "migration steps failed."
+        )
+
+        assert_raycluster_migrated_if_present()
+        assert_raycluster_ready_after_post_upgrade()
+
+        print(
+            "\n=== Ray migration post-upgrade finalize complete. "
+            "Proceed with post_upgrade job and UI tests. ===\n"
+        )

--- a/tests/upgrade/01_raycluster_sdk_upgrade_test.py
+++ b/tests/upgrade/01_raycluster_sdk_upgrade_test.py
@@ -11,11 +11,12 @@ from codeflare_sdk.ray.cluster.cluster import get_cluster
 
 from codeflare_sdk.common import _kube_api_error_handling
 
-namespace = "test-ns-rayupgrade"
-# Global variables for kueue resources
-cluster_queue = "cluster-queue-mnist"
-flavor = "default-flavor-mnist"
-local_queue = "local-queue-mnist"
+from tests.upgrade.constants import (
+    CLUSTER_QUEUE as cluster_queue,
+    LOCAL_QUEUE as local_queue,
+    NAMESPACE as namespace,
+    RESOURCE_FLAVOR as flavor,
+)
 
 
 # Creates a Ray cluster
@@ -120,7 +121,7 @@ class TestMnistJobSubmit:
         self.auth_instance = auth_instance
 
         self.namespace = namespace
-        self.cluster = get_cluster("mnist", self.namespace)
+        self.cluster = get_cluster("mnist", self.namespace, verify_tls=False)
         if not self.cluster:
             raise RuntimeError("TestRayClusterUp needs to be run before this test")
 

--- a/tests/upgrade/02_dashboard_ui_upgrade_test.py
+++ b/tests/upgrade/02_dashboard_ui_upgrade_test.py
@@ -31,9 +31,7 @@ from support import (
 
 # Fixtures are imported via conftest.py in this directory
 
-# Test configuration - should match the cluster created in raycluster_sdk_upgrade_test.py
-NAMESPACE = "test-ns-rayupgrade"
-CLUSTER_NAME = "mnist"
+from tests.upgrade.constants import CLUSTER_NAME, NAMESPACE
 
 
 @pytest.mark.pre_upgrade

--- a/tests/upgrade/README.md
+++ b/tests/upgrade/README.md
@@ -1,0 +1,341 @@
+# Ray upgrade tests (`tests/upgrade/`)
+
+Qualification flow for RHOAI Ray upgrades ([RHOAIENG-63109](https://issues.redhat.com/browse/RHOAIENG-63109)). Parent program: [RHAISTRAT-1519](https://redhat.atlassian.net/browse/RHAISTRAT-1519).
+
+**Documentation handoff:** [RHOAIENG-63115](https://redhat.atlassian.net/browse/RHOAIENG-63115) — this file is the component test-directory guide for coverage, limitations, ownership, and follow-ups.
+
+Upgrade qualification uses **two codeflare-sdk branches** and **two container runs** on the **same cluster** (same kubeconfig): pre on **2.25**, then OLM upgrade, then post on **3.x**.
+
+---
+
+## Branches and PRs
+
+| Phase | When | RHOAI | codeflare-sdk branch | Base | Tests in image |
+|-------|------|-------|----------------------|------|----------------|
+| **Pre-upgrade** | Before OLM upgrade | **2.25.x** | **`v0.31-pre-upgrade-clean`** | `v0.31` (`origin/v0.31`, ~0.31.5) | `pre_upgrade` only (see that branch’s README for image guard) |
+| **Post-upgrade** | After OLM upgrade | **3.x** (e.g. 3.3, 3.5 EA) | **`2.x-3.x-upgrade-tests-post-upgrade`** | **`main`** | `post_upgrade` (this branch) |
+
+- **Pre-upgrade branch** (`v0.31-pre-upgrade-clean`): seeds RayCluster, optional UI check, runs migration **pre-upgrade** (`codeflare: Removed`, route cleanup, backup). Does **not** include post-upgrade finalize tests (`00_*`, post migration helpers on this tree).
+- **Post-upgrade branch** (`2.x-3.x-upgrade-tests-post-upgrade`, merged to `main`): migration **post-upgrade**, MNIST job submit, UI after upgrade. Assumes pre phase already ran on the cluster (or equivalent lab state).
+- Branch-specific notes may also exist on **`v0.31-pre-upgrade-clean`** (`tests/upgrade/README.md` there focuses on pre only). **This file** is the consolidated guide on the post-upgrade line.
+
+**Jenkins / CI:** runs the published test image twice with `-m pre_upgrade` then `-m post_upgrade`; implementation lives in codeflare-sdk, not in Jenkins.
+
+---
+
+## End-to-end flow (2.25 → 3.x)
+
+```text
+[Cluster: RHOAI 2.25.x, ray Managed, kueue Unmanaged, …]
+
+1. Build image from v0.31-pre-upgrade-clean
+2. pytest -m pre_upgrade   (single session, then stop)
+     01  Seed RayCluster mnist + Kueue (test-ns-rayupgrade)
+     02  Dashboard UI (Workload Metrics) — optional if seed failed
+     03  Migration pre-upgrade finalize (script + DSC codeflare Removed)
+3. RHOAI OLM upgrade (outside this repo; channel per target, e.g. support-required-upgrade → 3.3, beta → 3.5 EA)
+
+4. Build image from 2.x-3.x-upgrade-tests-post-upgrade (main)
+5. pytest -m post_upgrade
+     00  Migration post-upgrade finalize
+     02  Dashboard UI
+     01  MNIST job submission
+```
+
+Use the **same** namespace (`test-ns-rayupgrade`) and cluster name (`mnist`) across pre and post. See `constants.py`.
+
+---
+
+## Markers
+
+| Marker | Phase | Typical branch / image |
+|--------|-------|-------------------------|
+| `pre_upgrade` | Before RHOAI OLM upgrade | **`v0.31-pre-upgrade-clean`** on 2.25 |
+| `post_upgrade` | After RHOAI OLM upgrade | **`2.x-3.x-upgrade-tests-post-upgrade`** (`main`) on 3.x |
+| `ui` | With pre or post UI tests | Combine: `-m "pre_upgrade and ui"` or `-m "post_upgrade and ui"` |
+
+---
+
+## Pre-upgrade (branch `v0.31-pre-upgrade-clean`)
+
+Run in **one** pytest session on **RHOAI 2.25**, then stop. Do **not** run OLM upgrade in the same session.
+
+### Test order
+
+1. `01_raycluster_sdk_upgrade_test.py` — seed `RayCluster` + Kueue objects
+2. `02_dashboard_ui_upgrade_test.py` — Workload Metrics UI (skipped meaningfully if seed failed)
+3. `03_ray_migration_pre_upgrade_finalize_test.py` — `ray_cluster_migration.py pre-upgrade`
+
+The finalize step (vendored from [rhoai-upgrade-helpers](https://github.com/red-hat-data-services/rhoai-upgrade-helpers)) sets **`codeflare: Removed`** on `DataScienceCluster` and other Ray pre-upgrade steps when clusters exist.
+
+**After finalize:** do not re-seed on 2.25 without reverting DSC (see [Retry after failure](#retry-after-failure)).
+
+### Build and run (pre)
+
+On **`v0.31-pre-upgrade-clean`**:
+
+```bash
+E2E_TEST_IMAGE_VERSION=test make build-test-image
+
+podman run --rm --platform linux/amd64 --pull=never \
+  -v "${KUBECONFIG:-$HOME/.kube/config}:/codeflare-sdk/tests/.kube/config:ro" \
+  -v "$(pwd)/tests/results:/codeflare-sdk/tests/results:Z" \
+  --env-file /path/to/cluster-env-file \
+  quay.io/opendatahub/codeflare-sdk-tests:test
+```
+
+That branch’s `run-tests.sh` defaults to **`pre_upgrade and not post_upgrade`** and **rejects** `-m post_upgrade` early. Passing `-m pre_upgrade` is normalized to that expression.
+
+```bash
+pytest tests/upgrade/ -m pre_upgrade -v
+```
+
+Pre-upgrade backups: `$RHOAI_UPGRADE_BACKUP_DIR/ray` (default `/tmp/rhoai-upgrade-backup/ray`). Used for rollback / `post-upgrade --from-backup`; not required for the default in-place post-upgrade path on 3.x.
+
+### Manual pre-upgrade script
+
+```bash
+python scripts/migration/ray_cluster_migration.py pre-upgrade \
+  --namespace test-ns-rayupgrade --cluster mnist
+```
+
+---
+
+## Post-upgrade (branch `2.x-3.x-upgrade-tests-post-upgrade` / `main`)
+
+Run on **RHOAI 3.x** after OLM upgrade, **same cluster** as pre.
+
+### Test order
+
+Collection order is enforced in `conftest.py`:
+
+1. `00_ray_migration_post_upgrade_finalize_test.py` — `ray_cluster_migration.py post-upgrade`
+2. `02_dashboard_ui_upgrade_test.py` — Workload Metrics UI
+3. `01_raycluster_sdk_upgrade_test.py` — MNIST job submission
+
+### Build and run (post)
+
+On **`2.x-3.x-upgrade-tests-post-upgrade`** (or `main` after merge):
+
+```bash
+E2E_TEST_IMAGE_VERSION=test make build-test-image
+
+podman run --rm --platform linux/amd64 --pull=never \
+  -v "${KUBECONFIG:-$HOME/.kube/config}:/codeflare-sdk/tests/.kube/config:ro" \
+  -v "$(pwd)/tests/results:/codeflare-sdk/tests/results:Z" \
+  --env-file /path/to/cluster-env-file \
+  quay.io/opendatahub/codeflare-sdk-tests:test \
+  -m post_upgrade -v
+```
+
+```bash
+pytest tests/upgrade/ -m post_upgrade -v
+pytest tests/upgrade/ -m "post_upgrade and ui" -v
+```
+
+This branch’s `run-tests.sh` includes `tests/upgrade/*_test.py` in the default oauth/upgrade set; pass **`-m post_upgrade`** explicitly for the post phase so e2e oauth tests are not run unless intended.
+
+### Manual post-upgrade script
+
+```bash
+python scripts/migration/ray_cluster_migration.py post-upgrade \
+  --namespace test-ns-rayupgrade --cluster mnist --yes
+```
+
+---
+
+## Cluster prerequisites (Testops / lab)
+
+Installed **before** `pre_upgrade`; not created by these tests:
+
+| Prerequisite | Notes |
+|--------------|--------|
+| RHOAI **2.25.x** for pre | e.g. `stable-2.25` → `rhods-operator.2.25.7` |
+| **`ray: Managed`** | KubeRay via RHOAI |
+| **`kueue: Unmanaged`** + RHBoK | Baseline for 3.x qualification path |
+| **cert-manager** | General 3.x prerequisite (Testops) |
+| **2→3:** `codeflare: Removed` before product upgrade | Pre finalize sets this; or manual per upgrade guide |
+| Same kubeconfig | Pre and post jobs must target the same cluster |
+
+For **2.25 → 3.5 EA**, use FBC channel **`beta`** from 2.25 (not `stable-2.25` → `stable-3.x` without a 2.25 bridge). For **2.25 → 3.3**, use **`support-required-upgrade`**. See program upgrade notes / `revised_todo.md` in the qualification repo.
+
+---
+
+## TLS / gateway dashboard (QE clusters)
+
+On many QE clusters, `rh-ai.apps.*` uses an ingress certificate that fails TLS verification from the test runner.
+
+- **Pre-upgrade** seed: `verify_tls=False` on `ClusterConfiguration`.
+- **Post-upgrade:** `get_cluster(name, namespace, verify_tls=False)` when loading the existing cluster.
+
+Without this, `cluster.wait_ready()` can hang on dashboard URL checks (`SSLError` treated as not ready even when **302** to OAuth is healthy). Bearer-token job tests are unaffected.
+
+---
+
+## BYOIDC detection (job submission)
+
+Post-upgrade job tests use `is_byoidc_cluster_detected()` from `tests/e2e/support.py` (aligned with `images/tests/run-tests.sh` on the pre branch).
+
+- **Not BYOIDC:** `status.oidcClients` with `componentName: cli` alone (normal on standard OpenShift).
+- **BYOIDC indicators:** `Authentication.spec.type == OIDC`, Keycloak issuer on `spec.oidcProviders` (rh-ods.com / qe.rh-ods.com), webhook token authenticators, or **`oc-cli`** in `status.oidcClients`.
+
+On **htpasswd/LDAP** QE clusters, job tests use `oc whoami --show-token=true` with `OCP_ADMIN_USER_*` — not Keycloak password grant.
+
+---
+
+## Migration script
+
+`scripts/migration/ray_cluster_migration.py` — keep in sync with [rhoai-upgrade-helpers](https://github.com/red-hat-data-services/rhoai-upgrade-helpers) `main`.
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `RHOAI_UPGRADE_BACKUP_DIR` | `/tmp/rhoai-upgrade-backup` | Backup root for pre-upgrade |
+| `RAY_CLUSTER_MIGRATION_SUPPRESS_TLS_WARNINGS` | `1` | Suppress urllib3 `InsecureRequestWarning` in the script via `urllib3.disable_warnings` |
+
+Annotations (see `constants.py`): `odh.ray.io/pre-upgrade-backup-taken`, `odh.ray.io/secure-trusted-network` (post-migration).
+
+**Known flake (pre, fresh cluster):** first `pre-upgrade` run may fail route assertion if KubeRay recreates Routes before `enableIngress: false` is applied; reruns usually pass. See qualification notes `script_fix_suggestion.md`.
+
+---
+
+## Retry after failure
+
+| Situation | Action |
+|-----------|--------|
+| Pre: seed/UI failed **before** finalize | Delete `test-ns-rayupgrade`, rerun `-m pre_upgrade` (DSC `codeflare` can stay Managed). |
+| Pre: finalize ran (`codeflare: Removed`) | Do **not** OLM-upgrade yet. Delete namespace, patch DSC `codeflare` → `Managed`, rerun `-m pre_upgrade` on **`v0.31-pre-upgrade-clean`**. |
+| Post: migration or job/UI failed | Fix cluster/3.x state; rerun `-m post_upgrade` on **`2.x-3.x-upgrade-tests-post-upgrade`**. Idempotent post-upgrade skips already-migrated CRs. |
+
+---
+
+## Constants
+
+`constants.py`:
+
+- Namespace: `test-ns-rayupgrade`
+- RayCluster: `mnist`
+- Kueue: `cluster-queue-mnist`, `local-queue-mnist`, `default-flavor-mnist`
+
+---
+
+## Upgrade path coverage
+
+Documented for [RHOAIENG-63115](https://redhat.atlassian.net/browse/RHOAIENG-63115) handoff. Primary qualification target: **RHOAI 2.25.7 → 3.5 EA** on the same cluster.
+
+| Upgrade path | Status | Notes |
+|--------------|--------|-------|
+| **2.25 → 3.5 EA** (`stable-2.25` → `beta`) | **Covered** | Primary path exercised in manual qualification; FBC channel graph documented above |
+| **2.25 → 3.3** (`stable-2.25` → `support-required-upgrade`) | **Supported, not routinely qualified** | Same pre/post test flow and migration script; OLM channel differs |
+| **3.x → 3.x** (e.g. `stable-3.x` within channel) | **Light coverage** | Post-upgrade skips 2→3 normalize when CR has no 2.x legacy; no dedicated 3.x→3.x qualification runbook yet |
+| **3.3 / 3.4** as explicit targets | **TBD** | Port/adapt after 2.25→3.5 path is green — see [Known gaps](#known-gaps-and-follow-ups) |
+| **GPU allocation survival** | **Not asserted** | 63111 mentions GPU checks; current tests do not validate GPU state across upgrade |
+| **Cross-component workflows** | **Out of scope** | Owned by feature / program teams under RHAISTRAT-1519 |
+| **opendatahub-tests mirror suite** | **Out of scope** | Implementation lives in codeflare-sdk; not a parallel opendatahub-tests tree |
+
+What these tests **do** validate on the covered 2→3 path:
+
+- Pre: RayCluster + Kueue seed, optional Workload Metrics UI, migration pre-finalize (`codeflare: Removed`, route cleanup, backup)
+- Post: migration post-finalize (2.x artefact strip / Gateway readiness), UI, MNIST RayJob submission on surviving cluster
+
+What they **do not** validate:
+
+- OLM upgrade orchestration itself (channel switch, bundle selection) — Testops / upgrade job
+- Operator install or DSC changes beyond migration script finalize steps
+- KubeRay operator behaviour in isolation — see [Shift-left validation](#shift-left-validation-operator-chaos) and kuberay lake gate
+
+---
+
+## Maintenance and ownership
+
+| Area | Owner | When to update |
+|------|-------|----------------|
+| `tests/upgrade/*`, pytest markers, `conftest.py` ordering | **Ray / codeflare-sdk** (distributed-workloads team) | Test flow, SDK job API, UI selectors, or cluster auth detection changes |
+| `images/tests/` (Dockerfile, `run-tests.sh`, RBAC manifest) | **Ray / codeflare-sdk** | Container entrypoint, marker guards, env-file contract |
+| `scripts/migration/ray_cluster_migration.py` (vendored copy) | **Ray team** — keep in sync with [rhoai-upgrade-helpers](https://github.com/red-hat-data-services/rhoai-upgrade-helpers) `main` | Migration behaviour, CRD/annotation handling, or pre/post finalize steps change |
+| `tests/upgrade/constants.py`, `migration_support.py` | **Ray / codeflare-sdk** | Qualification namespace/cluster IDs or wrapper behaviour |
+| Cluster prerequisites (RHOAI install, DSC, RHBoK, cert-manager, FBC image/channels) | **Testops** | Qualification cluster profile changes |
+| Same cluster + kubeconfig across pre/post Jenkins runs | **Testops / upgrade job** | Job wiring — not implemented in this repo |
+| Jenkins shift-left registration (`components-tests.yaml`, `-m pre_upgrade` / `-m post_upgrade`) | **DevTestOps** — see [RHOAIENG-63114](https://redhat.atlassian.net/browse/RHOAIENG-63114) | Gate registry only; pipeline owned by DevTestOps |
+| Pass/fail gating policy for release qualification | **Feature owner** ([RHAISTRAT-1519](https://redhat.atlassian.net/browse/RHAISTRAT-1519)) | Not owned by codeflare-sdk |
+| Migration script source of truth (non-vendored) | **rhoai-upgrade-helpers** maintainers | Authoritative script changes land there first; vendored copy updated in both pre and post branches |
+
+**Pre branch maintenance:** `v0.31-pre-upgrade-clean` (PR to `v0.31`) — pre_upgrade tests and vendored migration script for 2.25. Keep migration script aligned with this branch when helpers change.
+
+**Post branch maintenance:** `2.x-3.x-upgrade-tests-post-upgrade` (PR to `main`) — post_upgrade tests and post-phase migration helpers. **This README** is the consolidated handoff doc after merge to `main`.
+
+When Ray or KubeRay APIs change, expect coordinated updates in:
+
+1. [opendatahub-io/kuberay](https://github.com/opendatahub-io/kuberay) (operator, CRDs, operator-chaos knowledge model)
+2. [rhoai-upgrade-helpers](https://github.com/red-hat-data-services/rhoai-upgrade-helpers) (migration script)
+3. codeflare-sdk `tests/upgrade/` and vendored `scripts/migration/` (this repo)
+
+---
+
+## Shift-left validation (operator-chaos)
+
+Upgrade tests in this directory are **integration** validation on a live cluster (pre/post OLM upgrade). **PR-time** breaking-change detection for the KubeRay operator is separate — [RHOAIENG-63113](https://redhat.atlassian.net/browse/RHOAIENG-63113).
+
+| Layer | Repo | Purpose |
+|-------|------|---------|
+| Integration (this doc) | codeflare-sdk `tests/upgrade/` | End-to-end Ray workload + migration script on qualification cluster |
+| Shift-left | [opendatahub-io/kuberay](https://github.com/opendatahub-io/kuberay) | operator-chaos on PRs that touch APIs, CRDs, or controllers |
+
+**Maturity adopted (63113):** **Level 1 + Level 2 (dry-run)** on the KubeRay operator repo.
+
+- **Workflow:** [`.github/workflows/operator-chaos.yml`](https://github.com/opendatahub-io/kuberay/blob/dev/.github/workflows/operator-chaos.yml) on `dev` (runs on PRs touching `ray-operator/apis/**`, CRDs, controllers, or `chaos/knowledge/**`).
+- **Level 1:** `operator-chaos diff` / `diff-crds` with `--breaking` — fails PR if breaking knowledge-model or CRD schema changes lack a documented migration path.
+- **Level 2:** `operator-chaos simulate-upgrade --dry-run` against the knowledge model diff.
+- **Knowledge model:** `chaos/knowledge/kuberay.yaml` in [opendatahub-io/kuberay](https://github.com/opendatahub-io/kuberay). **Maintain when** RayCluster / RayJob CRDs, webhook behaviour, or controller reconciliation logic changes — update the YAML in the same PR as the API/controller change.
+- **Not adopted:** Level 3 (ChaosClient in controller integration tests) and Level 4 (OLM channel-hop playbook) — tracked as follow-ups under 63113 / Ray backlog.
+
+These upgrade tests do **not** replace operator-chaos; they complement it (shift-left catches schema drift early; integration tests catch migration + workload behaviour on real clusters).
+
+**KubeRay lake gate:** Jenkins `kuberay-lake-gate` runs Tier1 e2e against operator images built from `dev` — component verification, not part of this upgrade test suite. See [Known gaps](#known-gaps-and-follow-ups).
+
+---
+
+## Known limitations
+
+| Limitation | Impact | Mitigation |
+|------------|--------|------------|
+| **Pre-upgrade route flake (fresh cluster)** | KubeRay may recreate OpenShift Routes before `enableIngress: false` is applied | Rerun `-m pre_upgrade`; see qualification notes `script_fix_suggestion.md` |
+| **TLS on QE dashboard URLs** | `cluster.wait_ready()` may hang on `SSLError` | `verify_tls=False` on seed/load — documented in [TLS / gateway dashboard](#tls--gateway-dashboard-qe-clusters) |
+| **Single qualification identity** | Tests assume `test-ns-rayupgrade` / `mnist` | Do not re-seed after pre finalize without DSC revert — see [Retry after failure](#retry-after-failure) |
+| **Two-branch / two-image model** | Pre and post require different codeflare-sdk branches and images | Operational complexity; intentional for 2.25 SDK vs 3.x SDK lines |
+| **BYOIDC vs htpasswd/LDAP** | Job submission auth path differs | Auto-detected; wrong env file causes post job failures |
+| **FBC channel selection** | Wrong channel (e.g. `stable-2.25` → `stable-3.x`) blocks OLM 2→3 | Use `beta` (3.5 EA) or `support-required-upgrade` (3.3) — see [Cluster prerequisites](#cluster-prerequisites-testops--lab) |
+| **Vendored migration script drift** | Pre/post branches can diverge from helpers `main` | Sync `scripts/migration/ray_cluster_migration.py` from rhoai-upgrade-helpers on every migration change |
+| **No GPU assertion** | GPU-backed clusters not explicitly qualified | Follow-up — see below |
+
+---
+
+## Known gaps and follow-ups
+
+Remaining gaps are **not** blockers for merging upgrade test implementation ([RHOAIENG-63111](https://redhat.atlassian.net/browse/RHOAIENG-63111)); track as separate Jira tickets under the [RHOAIENG-63109](https://redhat.atlassian.net/browse/RHOAIENG-63109) epic or Ray team backlog:
+
+| Gap | Suggested owner | Notes |
+|-----|-----------------|-------|
+| Routine **3.3 / 3.4** upgrade qualification | Ray / Testops | Adapt channel + FBC pins after 2.25→3.5 path is green |
+| Dedicated **3.x → 3.x** runbook and markers | Ray / codeflare-sdk | Light path exists; no formal qualification doc yet |
+| **GPU allocation** survival across upgrade | Ray / codeflare-sdk | Called out in 63111; not implemented in current tests |
+| **opendatahub-tests** parity (if program still requires) | Ray / opendatahub-tests | This repo is the primary implementation; mirror only if mandated |
+| operator-chaos **Level 3 / 4** (ChaosClient, OLM playbook) | Ray / kuberay | Follow-on from [RHOAIENG-63113](https://redhat.atlassian.net/browse/RHOAIENG-63113) |
+| **KFTO** / training-operator upgrade interactions | Feature team | Out of scope for Ray upgrade tests |
+| Formal **data backup/restore** via OADP | Testops / program | 63111 mentions OCP backup procedures; tests use migration script backup dir only |
+
+File follow-up Jira issues for items your team commits to address; link them from this table when created.
+
+---
+
+## Out of scope (this repository)
+
+- **Jenkins pipeline development** — consumers invoke the published test image with `-m pre_upgrade` / `-m post_upgrade` only ([RHOAIENG-63114](https://redhat.atlassian.net/browse/RHOAIENG-63114))
+- **Installing RHOAI or operators** beyond what the migration script adjusts during finalize
+- **Cross-component upgrade scenarios** and **pass/fail release gating policy**
+- **Primary implementation in opendatahub-tests** — see [Upgrade path coverage](#upgrade-path-coverage)
+
+Related but owned elsewhere:
+
+- **operator-chaos** — kuberay repo ([Shift-left validation](#shift-left-validation-operator-chaos))
+- **KubeRay lake gate** — Jenkins shift-left on `dev` branch images
+- **rhoai-upgrade-helpers** — migration script source of truth (vendored here)

--- a/tests/upgrade/conftest.py
+++ b/tests/upgrade/conftest.py
@@ -1,48 +1,53 @@
 # Copyright 2024 IBM, Red Hat
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# Conftest for upgrade tests - UI fixtures and post_upgrade test ordering.
 
-"""
-Conftest for upgrade tests - imports UI fixtures for dashboard tests
-"""
-
-import sys
 import os
+import sys
+
 import pytest
 
-# Add parent test directory to path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-# Import all fixtures from ui/conftest.py
 from ui.conftest import (
-    selenium_driver,
     dashboard_url,
-    test_credentials,
     login_to_dashboard,
+    selenium_driver,
+    test_credentials,
 )
 
-__all__ = ["selenium_driver", "dashboard_url", "test_credentials", "login_to_dashboard"]
+__all__ = [
+    "selenium_driver",
+    "dashboard_url",
+    "test_credentials",
+    "login_to_dashboard",
+]
 
 
-# Hook to capture test results for teardown methods
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_runtest_makereport(item, call):
-    """
-    Hook to capture test results and make them available to teardown methods.
-    This allows teardown_method to check if the test failed.
-    """
+    """Capture test results for teardown methods (cleanup_on_failure fixtures)."""
     outcome = yield
     rep = outcome.get_result()
-
-    # Store the result in the item so teardown can access it
     setattr(item, f"rep_{rep.when}", rep)
+
+
+def pytest_collection_modifyitems(config, items):
+    """
+    Run Ray migration post-upgrade before other post_upgrade tests (job submit, UI).
+    """
+    pre_and_other = []
+    post_migration = []
+    post_other = []
+
+    for item in items:
+        if not item.get_closest_marker("post_upgrade"):
+            pre_and_other.append(item)
+            continue
+        if "TestRayMigrationPostUpgradeFinalize" in item.nodeid:
+            post_migration.append(item)
+        else:
+            post_other.append(item)
+
+    if post_migration:
+        items[:] = pre_and_other + post_migration + post_other

--- a/tests/upgrade/constants.py
+++ b/tests/upgrade/constants.py
@@ -1,0 +1,14 @@
+# Copyright 2024 IBM, Red Hat
+#
+# Shared identifiers for Ray upgrade qualification tests (2.25 pre / 3.x post).
+
+NAMESPACE = "test-ns-rayupgrade"
+CLUSTER_NAME = "mnist"
+
+CLUSTER_QUEUE = "cluster-queue-mnist"
+RESOURCE_FLAVOR = "default-flavor-mnist"
+LOCAL_QUEUE = "local-queue-mnist"
+
+# Matches rhoai-upgrade-helpers ray_cluster_migration.py
+PRE_UPGRADE_BACKUP_ANNOTATION = "odh.ray.io/pre-upgrade-backup-taken"
+SECURE_NETWORK_ANNOTATION = "odh.ray.io/secure-trusted-network"

--- a/tests/upgrade/migration_support.py
+++ b/tests/upgrade/migration_support.py
@@ -1,0 +1,177 @@
+# Copyright 2024 IBM, Red Hat
+#
+# Invoke scripts/migration/ray_cluster_migration.py from upgrade tests (no duplicated logic).
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+from tests.upgrade.constants import (
+    CLUSTER_NAME,
+    NAMESPACE,
+    SECURE_NETWORK_ANNOTATION,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_SCRIPT = PROJECT_ROOT / "scripts" / "migration" / "ray_cluster_migration.py"
+DEFAULT_BACKUP_BASE = os.environ.get(
+    "RHOAI_UPGRADE_BACKUP_DIR", "/tmp/rhoai-upgrade-backup"
+)
+
+SUPPRESS_TLS_WARNINGS_ENV = "RAY_CLUSTER_MIGRATION_SUPPRESS_TLS_WARNINGS"
+
+_post_upgrade_invoked = False
+
+
+def _migration_subprocess_env(backup_base_dir: str) -> dict:
+    env = os.environ.copy()
+    env["RHOAI_UPGRADE_BACKUP_DIR"] = backup_base_dir
+    # TLS warning suppression is handled inside ray_cluster_migration.py via
+    # urllib3.disable_warnings (PYTHONWARNINGS ignore::urllib3... is invalid on Python 3.13+).
+    return env
+
+
+def mark_migration_post_upgrade_invoked() -> None:
+    global _post_upgrade_invoked
+    _post_upgrade_invoked = True
+
+
+def migration_post_upgrade_was_invoked() -> bool:
+    return _post_upgrade_invoked
+
+
+def run_migration_post_upgrade(
+    namespace: str = NAMESPACE,
+    cluster_name: str = CLUSTER_NAME,
+    backup_base_dir: str = DEFAULT_BACKUP_BASE,
+    dry_run: bool = False,
+) -> subprocess.CompletedProcess:
+    """
+    Run ray_cluster_migration.py post-upgrade for the qualification RayCluster.
+
+    Uses --yes for non-interactive CI/container runs. Idempotent when already migrated.
+    """
+    if not MIGRATION_SCRIPT.is_file():
+        raise FileNotFoundError(
+            f"Migration script not found at {MIGRATION_SCRIPT}. "
+            "Ensure scripts/migration/ray_cluster_migration.py is present."
+        )
+
+    cmd: List[str] = [
+        sys.executable,
+        str(MIGRATION_SCRIPT),
+        "post-upgrade",
+        "--namespace",
+        namespace,
+        "--cluster",
+        cluster_name,
+        "--yes",
+    ]
+    if dry_run:
+        cmd.append("--dry-run")
+
+    env = _migration_subprocess_env(backup_base_dir)
+
+    print(f"\n=== Running migration post-upgrade: {' '.join(cmd)} ===\n")
+    result = subprocess.run(
+        cmd,
+        cwd=str(PROJECT_ROOT),
+        env=env,
+        capture_output=False,
+        text=True,
+        check=False,
+    )
+    mark_migration_post_upgrade_invoked()
+    return result
+
+
+def _load_kube_config() -> None:
+    try:
+        config.load_kube_config(
+            config_file=os.environ.get(
+                "KUBECONFIG", os.path.expanduser("~/.kube/config")
+            )
+        )
+    except config.ConfigException:
+        config.load_incluster_config()
+
+
+def raycluster_exists(
+    namespace: str = NAMESPACE, cluster_name: str = CLUSTER_NAME
+) -> bool:
+    _load_kube_config()
+    api = client.CustomObjectsApi()
+    try:
+        api.get_namespaced_custom_object(
+            group="ray.io",
+            version="v1",
+            namespace=namespace,
+            plural="rayclusters",
+            name=cluster_name,
+        )
+        return True
+    except ApiException as e:
+        if e.status == 404:
+            return False
+        raise
+
+
+def assert_raycluster_migrated_if_present(
+    namespace: str = NAMESPACE,
+    cluster_name: str = CLUSTER_NAME,
+) -> None:
+    """Assert 2→3 migration markers on the qualification RayCluster when it exists."""
+    if not raycluster_exists(namespace, cluster_name):
+        raise AssertionError(
+            f"RayCluster '{cluster_name}' not found in '{namespace}' after post-upgrade. "
+            "Run pre_upgrade seed tests before the RHOAI upgrade."
+        )
+
+    _load_kube_config()
+    api = client.CustomObjectsApi()
+    rc = api.get_namespaced_custom_object(
+        group="ray.io",
+        version="v1",
+        namespace=namespace,
+        plural="rayclusters",
+        name=cluster_name,
+    )
+    annotations = (rc.get("metadata") or {}).get("annotations") or {}
+    if annotations.get(SECURE_NETWORK_ANNOTATION) != "true":
+        raise AssertionError(
+            f"RayCluster '{cluster_name}' missing {SECURE_NETWORK_ANNOTATION}=true "
+            "after post-upgrade migration."
+        )
+    print(
+        f"Confirmed RayCluster '{cluster_name}' has {SECURE_NETWORK_ANNOTATION}=true."
+    )
+
+
+def assert_raycluster_ready_after_post_upgrade(
+    namespace: str = NAMESPACE,
+    cluster_name: str = CLUSTER_NAME,
+    timeout: int = 600,
+) -> None:
+    from codeflare_sdk.ray.cluster.cluster import get_cluster
+
+    from tests.e2e.support import wait_ready_with_stuck_detection
+
+    # Match pre_upgrade seed tests: rh-ai gateway uses cluster ingress CA (verify fails locally).
+    cluster = get_cluster(cluster_name, namespace, verify_tls=False)
+    if not cluster:
+        raise AssertionError(
+            f"RayCluster '{cluster_name}' not found in '{namespace}' for readiness check."
+        )
+
+    wait_ready_with_stuck_detection(cluster, timeout=timeout)
+    _, ready = cluster.status()
+    if not ready:
+        raise AssertionError(
+            f"RayCluster '{cluster_name}' is not Ready after post-upgrade migration."
+        )
+    print(f"RayCluster '{cluster_name}' is Ready after post-upgrade migration.")


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63111

# What changes have been made
added idempotent migration script to be executed before original post-upgrade tests to migrate (if applicable) ray clusters from 2.x to 3.x

# Verification steps
- run pre-upgrade tests with this [branch](https://github.com/project-codeflare/codeflare-sdk/pull/1097), 
- upgrade RHOAI to 3.5EA2
- build an image with this branch
- run post_upgrade tests with the new image

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->