### PR TITLE
RHOAIENG-68184: fix intermittent test failure

### DIFF
--- a/tests/e2e/rayjob/rayjob_lifecycled_cluster_test.py
+++ b/tests/e2e/rayjob/rayjob_lifecycled_cluster_test.py
@@ -138,8 +138,12 @@ class TestRayJobLifecycledCluster:
                 local_queue=self.local_queues[0],
             )
             assert job1.submit() == "holder"
-            assert self.job_api.wait_until_job_running(
-                name=job1.name, k8s_namespace=job1.namespace, timeout=60
+            assert wait_for_kueue_admission(
+                self, self.job_api, job1.name, job1.namespace, timeout=120
+            ), f"RayJob {job1.name} was not admitted by Kueue"
+            job_running = self._wait_for_job_running_with_retry(job1, max_retries=1)
+            assert job_running, (
+                f"RayJob {job1.name} failed to reach running state after retries"
             )
 
             job2 = RayJob(
@@ -176,15 +180,15 @@ class TestRayJobLifecycledCluster:
             assert job_is_queued, "Job2 should be queued by Kueue while Job1 is running"
 
             assert self.job_api.wait_until_job_finished(
-                name=job1.name, k8s_namespace=job1.namespace, timeout=60
+                name=job1.name, k8s_namespace=job1.namespace, timeout=120
             )
 
             assert wait_for_kueue_admission(
-                self, self.job_api, job2.name, job2.namespace, timeout=30
+                self, self.job_api, job2.name, job2.namespace, timeout=120
             )
 
             assert self.job_api.wait_until_job_finished(
-                name=job2.name, k8s_namespace=job2.namespace, timeout=60
+                name=job2.name, k8s_namespace=job2.namespace, timeout=300
             )
         finally:
             for job in [job1, job2]:


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/RHOAIENG-68184

# What changes have been made
[RHOAIENG-68184](https://redhat.atlassian.net/browse/RHOAIENG-68184): fix intermittent test failure

### Before fix (intermittently)
```
======================================================================================================================= FAILURES =======================================================================================================================
_________________________________________________________________________________________ TestRayJobLifecycledCluster.test_lifecycled_kueue_resource_queueing __________________________________________________________________________________________
tests/e2e/rayjob/rayjob_lifecycled_cluster_test.py:141: in test_lifecycled_kueue_resource_queueing
    assert self.job_api.wait_until_job_running(
E   AssertionError: assert False
E    +  where False = wait_until_job_running(name='holder', k8s_namespace='test-ns-dbv3g', timeout=60)
E    +    where wait_until_job_running = <codeflare_sdk.vendored.python_client.kuberay_job_api.RayjobApi object at 0x7fffda2e2f60>.wait_until_job_running
E    +      where <codeflare_sdk.vendored.python_client.kuberay_job_api.RayjobApi object at 0x7fffda2e2f60> = <rayjob.rayjob_lifecycled_cluster_test.TestRayJobLifecycledCluster object at 0x7fffd9d8c8f0>.job_api
E    +    and   'holder' = <codeflare_sdk.ray.rayjobs.rayjob.RayJob object at 0x7fffd93442c0>.name
E    +    and   'test-ns-dbv3g' = <codeflare_sdk.ray.rayjobs.rayjob.RayJob object at 0x7fffd93442c0>.namespace
```

### After fix
test passes 100% of the time

# Verification steps
N/A - verified locally though several times - issue no longer persiss

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [x] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->