### PR TITLE
Add supply-chain security controls (RHOAIENG-68528)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,13 @@ updates:
       - "test-guided-notebooks"
       - "test-ui-notebooks"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependabot"
+
   # npm means yarn in this case, this keeps yarn.lock up to date with constraints in package.json.
   - package-ecosystem: "npm"
     directory: "/ui-tests"

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,35 @@
+name: Dependency Audit
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '15 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install poetry and export plugin
+        run: pip install poetry poetry-plugin-export
+
+      - name: Export requirements
+        run: poetry export -f requirements.txt --without-hashes -o requirements.txt
+
+      - name: Run pip-audit
+        uses: pypa/gh-action-pip-audit@v1
+        with:
+          inputs: requirements.txt

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 2 * * 0'
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,10 @@ repos:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+        exclude: "(^tests/|vendored/|^demo-notebooks/|^ui-tests/|test_.*\\.py$|conftest\\.py$|unit_test_support\\.py$)"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,38 @@
+# Security Policy
+
+The CodeFlare SDK project takes security seriously. This document describes
+how to report security vulnerabilities and how they are handled.
+
+## Supported Versions
+
+Security fixes are applied to the latest release branch and to `main`.
+Older releases are not actively patched. Users should upgrade to the
+latest version.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in CodeFlare SDK, please
+report it responsibly. **Do not open a public GitHub issue for
+security vulnerabilities.**
+
+Please report security issues by emailing **secalert@redhat.com**.
+Include as much detail as possible:
+
+- Description of the vulnerability
+- Steps to reproduce or proof-of-concept
+- Affected versions
+- Potential impact
+
+You can also use the
+[Red Hat Product Security](https://access.redhat.com/security/team/contact/)
+portal for reporting.
+
+The Red Hat Product Security team will acknowledge your report,
+assess the issue, and coordinate a fix and disclosure timeline.
+
+## Disclosure Policy
+
+We follow
+[Red Hat's vulnerability disclosure policy](https://access.redhat.com/security/vulnerability-policy/).
+Security issues are addressed under embargo until a fix is available,
+at which point a coordinated disclosure is made.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,13 @@ module = [
 ]
 ignore_errors = true
 
+[tool.bandit]
+skips = [
+    "B104",  # binding to 0.0.0.0 is intentional for Ray dashboard in K8s pods
+    "B108",  # /tmp paths are inside submitter pods, not host filesystem
+    "B110",  # try/except/pass used intentionally for optional K8s API checks
+]
+
 [build-system]
 requires = ["poetry-core>=1.6.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Address security audit finding FIND-014 by adding vulnerability disclosure policy, dependency scanning, security linting, and supply-chain scoring to CI.

- Add SECURITY.md with Red Hat Product Security disclosure process
- Add OpenSSF Scorecard workflow (weekly + on push to main)
- Add pip-audit workflow for dependency vulnerability scanning on PRs
- Add bandit pre-commit hook for Python security linting
- Add github-actions ecosystem to Dependabot for Action updates

# Issue link
<!-- insert a link to the GitHub issue -->
<!-- If the issue is closed with this PR enter 'Closes #<issue_number>' -->

# What changes have been made
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Checks
- [ ] I've made sure the tests are passing. 
- Testing Strategy
   - [ ] Unit tests
   - [ ] Manual tests
   - [ ] Testing is not required for this change

<!-- You can find out information on the review process at this link https://github.com/project-codeflare/codeflare/blob/develop/CONTRIBUTING.md#getting-feedback-on-your-contribution -->